### PR TITLE
[Feat] 회원가입 화면 웹뷰 구현 및 웹뷰 기본 셋팅

### DIFF
--- a/app/src/main/java/com/team/bottles/di/usecase/UseCaseModule.kt
+++ b/app/src/main/java/com/team/bottles/di/usecase/UseCaseModule.kt
@@ -2,6 +2,8 @@ package com.team.bottles.di.usecase
 
 import com.team.bottles.core.domain.auth.usecase.LoginWithKakaoUseCase
 import com.team.bottles.core.domain.auth.usecase.LoginWithKakaoUseCaseImpl
+import com.team.bottles.core.domain.auth.usecase.WebViewConnectUseCase
+import com.team.bottles.core.domain.auth.usecase.WebViewConnectUseCaseImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -15,5 +17,10 @@ abstract class UseCaseModule {
     abstract fun bindsLoginWithKaKaoUseCase(
         useCaseImpl: LoginWithKakaoUseCaseImpl
     ): LoginWithKakaoUseCase
+
+    @Binds
+    abstract fun bindsWebViewConnectUseCase(
+        useCaseImpl: WebViewConnectUseCaseImpl
+    ): WebViewConnectUseCase
 
 }

--- a/app/src/main/java/com/team/bottles/navigation/BottlesNavHost.kt
+++ b/app/src/main/java/com/team/bottles/navigation/BottlesNavHost.kt
@@ -47,14 +47,14 @@ fun BottlesNavHost(
             bottleBoxScreen(navigateToBottle = ::navigateToBottle)
             introductionScreen(navigateToSandBeach = ::navigateToSandBeach)
             bottleScreen(navigateToBottleBox = ::navigateToBottleBox)
-            myPageScreen(navigateToLogin = ::navigateToLogin)
+            myPageScreen(navigateToLogin = ::navigateToLoginEndpoint)
             signupScreen(
                 navigateToSandBeach = ::navigateToSandBeach,
-                navigateToLogin = ::navigateToLogin
+                navigateToLoginEndpoint = ::navigateToLoginEndpoint
             )
             smsLoginScreen(
                 navigateToSandBeach = ::navigateToSandBeach,
-                navigateToLogin = ::navigateToLogin
+                navigateToLogin = ::navigateToLoginEndpoint
             )
         }
     }
@@ -87,7 +87,7 @@ fun NavController.navigateToBottleBox() =
         popUpTo(graph.id)
     }
 
-fun NavController.navigateToLogin() =
+fun NavController.navigateToLoginEndpoint() =
     navigate(LoginNavigator.Endpoint) {
         popUpTo(graph.id)
     }

--- a/core/common/src/main/kotlin/com/team/bottles/core/common/base/BaseBridgeListener.kt
+++ b/core/common/src/main/kotlin/com/team/bottles/core/common/base/BaseBridgeListener.kt
@@ -1,0 +1,9 @@
+package com.team.bottles.core.common.base
+
+abstract class BaseBridgeListener {
+
+    abstract fun onWebViewClose()
+
+    open fun onToastOpen(message: String) {}
+
+}

--- a/core/data/src/main/kotlin/com/team/bottles/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/team/bottles/core/data/repository/AuthRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.team.bottles.core.data.repository
 import com.team.bottles.core.data.model.toAuthResult
 import com.team.bottles.core.datastore.datasource.TokenDataSource
 import com.team.bottles.core.domain.auth.model.AuthResult
+import com.team.bottles.core.domain.auth.model.Token
 import com.team.bottles.core.domain.auth.repository.AuthRepository
 import com.team.bottles.network.datasource.AuthDataSource
 import com.team.bottles.network.dto.auth.request.KakaoSignInUpRequest
@@ -24,6 +25,17 @@ class AuthRepositoryImpl @Inject constructor(
     override suspend fun logout() {
         val accessToken = tokenDataSource.getAccessToken()
         authDataSource.logout(accessToken = accessToken)
+    }
+
+    override suspend fun fetchLocalToken(): Token =
+        Token(
+            accessToken = tokenDataSource.getAccessToken(),
+            refreshToken = tokenDataSource.getRefreshToken()
+        )
+
+    override suspend fun updateLocalToken(token: Token) {
+        tokenDataSource.setAccessToken(accessToken = token.accessToken)
+        tokenDataSource.setRefreshToken(refreshToken = token.refreshToken)
     }
 
 }

--- a/core/domain/src/main/kotlin/com/team/bottles/core/domain/auth/model/Token.kt
+++ b/core/domain/src/main/kotlin/com/team/bottles/core/domain/auth/model/Token.kt
@@ -1,0 +1,9 @@
+package com.team.bottles.core.domain.auth.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Token(
+    val accessToken: String,
+    val refreshToken: String
+)

--- a/core/domain/src/main/kotlin/com/team/bottles/core/domain/auth/model/Token.kt
+++ b/core/domain/src/main/kotlin/com/team/bottles/core/domain/auth/model/Token.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class Token(
-    val accessToken: String,
-    val refreshToken: String
+    val accessToken: String = "",
+    val refreshToken: String = ""
 )

--- a/core/domain/src/main/kotlin/com/team/bottles/core/domain/auth/repository/AuthRepository.kt
+++ b/core/domain/src/main/kotlin/com/team/bottles/core/domain/auth/repository/AuthRepository.kt
@@ -1,11 +1,16 @@
 package com.team.bottles.core.domain.auth.repository
 
 import com.team.bottles.core.domain.auth.model.AuthResult
+import com.team.bottles.core.domain.auth.model.Token
 
 interface AuthRepository {
 
     suspend fun kakaoLogin(accessToken: String): AuthResult
 
     suspend fun logout()
+
+    suspend fun fetchLocalToken(): Token
+
+    suspend fun updateLocalToken(token: Token)
 
 }

--- a/core/domain/src/main/kotlin/com/team/bottles/core/domain/auth/usecase/WebViewConnectUseCase.kt
+++ b/core/domain/src/main/kotlin/com/team/bottles/core/domain/auth/usecase/WebViewConnectUseCase.kt
@@ -1,0 +1,27 @@
+package com.team.bottles.core.domain.auth.usecase
+
+import com.team.bottles.core.domain.auth.model.Token
+import com.team.bottles.core.domain.auth.repository.AuthRepository
+import javax.inject.Inject
+
+class WebViewConnectUseCaseImpl @Inject constructor(
+    private val authRepository: AuthRepository
+): WebViewConnectUseCase {
+
+    override suspend fun getLocalToken(): Token =
+        authRepository.fetchLocalToken()
+
+    override suspend fun setLocalToken(token: Token) {
+        authRepository.updateLocalToken(token = token)
+    }
+
+}
+
+
+interface WebViewConnectUseCase {
+
+    suspend fun getLocalToken(): Token
+
+    suspend fun setLocalToken(token: Token)
+
+}

--- a/feat/signup/build.gradle.kts
+++ b/feat/signup/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.konan.properties.Properties
+
 plugins {
     id("team.bottles.android.library.compose")
     id("team.bottles.android.library")
@@ -8,6 +10,26 @@ plugins {
 
 android {
     namespace = "com.team.bottles.feat.signup"
+
+    buildTypes {
+        val debugUrl = "BOTTLES_SIGNUP_URL"
+        val properties = Properties().apply { load(rootProject.file("local.properties").inputStream()) }
+
+        getByName("release") {
+            buildConfigField(
+                "String",
+                debugUrl, // TODO : 릴리즈 용 URL 생성 가능성 있음
+                properties.getProperty(debugUrl) // // TODO : 릴리즈 용 URL 생성 가능성 있음
+            )
+        }
+        getByName("debug") {
+            buildConfigField(
+                "String",
+                debugUrl,
+                properties.getProperty(debugUrl)
+            )
+        }
+    }
 }
 
 dependencies {

--- a/feat/signup/src/main/kotlin/com/team/bottles/feat/signup/SignupBridge.kt
+++ b/feat/signup/src/main/kotlin/com/team/bottles/feat/signup/SignupBridge.kt
@@ -5,28 +5,23 @@ import com.team.bottles.core.common.base.BaseBridgeListener
 import com.team.bottles.core.domain.auth.model.Token
 import kotlinx.serialization.json.Json
 
-internal class SignupBridge(private val onEvent: (SignupWebEvent) -> Unit) :
+internal class SignupBridge(private val onAction: (SignupWebAction) -> Unit) :
     SignupBridgeListener() {
 
     @JavascriptInterface
     override fun onSignup(json: String) {
         val token = Json.decodeFromString<Token>(json)
-        onEvent(
-            SignupWebEvent.OnSignup(
-                accessToken = token.accessToken,
-                refreshToken = token.refreshToken
-            )
-        )
+        onAction(SignupWebAction.OnSignup(token =token))
     }
 
     @JavascriptInterface
     override fun onWebViewClose() {
-        onEvent(SignupWebEvent.OnWebViewClose)
+        onAction(SignupWebAction.OnWebViewClose)
     }
 
     @JavascriptInterface
     override fun onToastOpen(message: String) {
-        onEvent(SignupWebEvent.OnToastOpen(message = message))
+        onAction(SignupWebAction.OnToastOpen(message = message))
     }
 
     companion object {
@@ -35,13 +30,13 @@ internal class SignupBridge(private val onEvent: (SignupWebEvent) -> Unit) :
 
 }
 
-sealed interface SignupWebEvent {
+sealed interface SignupWebAction {
 
-    data class OnSignup(val accessToken: String, val refreshToken: String) : SignupWebEvent
+    data class OnSignup(val token: Token) : SignupWebAction
 
-    data object OnWebViewClose : SignupWebEvent
+    data object OnWebViewClose : SignupWebAction
 
-    data class OnToastOpen(val message: String) : SignupWebEvent
+    data class OnToastOpen(val message: String) : SignupWebAction
 
 }
 

--- a/feat/signup/src/main/kotlin/com/team/bottles/feat/signup/SignupBridge.kt
+++ b/feat/signup/src/main/kotlin/com/team/bottles/feat/signup/SignupBridge.kt
@@ -1,0 +1,52 @@
+package com.team.bottles.feat.signup
+
+import android.webkit.JavascriptInterface
+import com.team.bottles.core.common.base.BaseBridgeListener
+import com.team.bottles.core.domain.auth.model.Token
+import kotlinx.serialization.json.Json
+
+internal class SignupBridge(private val onEvent: (SignupWebEvent) -> Unit) :
+    SignupBridgeListener() {
+
+    @JavascriptInterface
+    override fun onSignup(json: String) {
+        val token = Json.decodeFromString<Token>(json)
+        onEvent(
+            SignupWebEvent.OnSignup(
+                accessToken = token.accessToken,
+                refreshToken = token.refreshToken
+            )
+        )
+    }
+
+    @JavascriptInterface
+    override fun onWebViewClose() {
+        onEvent(SignupWebEvent.OnWebViewClose)
+    }
+
+    @JavascriptInterface
+    override fun onToastOpen(message: String) {
+        onEvent(SignupWebEvent.OnToastOpen(message = message))
+    }
+
+    companion object {
+        const val NAME = "Native"
+    }
+
+}
+
+sealed interface SignupWebEvent {
+
+    data class OnSignup(val accessToken: String, val refreshToken: String) : SignupWebEvent
+
+    data object OnWebViewClose : SignupWebEvent
+
+    data class OnToastOpen(val message: String) : SignupWebEvent
+
+}
+
+abstract class SignupBridgeListener : BaseBridgeListener() {
+
+    abstract fun onSignup(json: String)
+
+}

--- a/feat/signup/src/main/kotlin/com/team/bottles/feat/signup/SignupRoute.kt
+++ b/feat/signup/src/main/kotlin/com/team/bottles/feat/signup/SignupRoute.kt
@@ -10,7 +10,7 @@ import com.team.bottles.feat.signup.mvi.SignupSideEffect
 @Composable
 fun SignupRoute(
     viewModel: SignupViewModel = hiltViewModel(),
-    navigateToLogin: () -> Unit,
+    navigateToLoginEndpoint: () -> Unit,
     navigateToSandBeach: () -> Unit
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
@@ -19,7 +19,7 @@ fun SignupRoute(
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
                 is SignupSideEffect.NavigateToSandBeach -> navigateToSandBeach()
-                is SignupSideEffect.NavigateToLogin -> navigateToLogin()
+                is SignupSideEffect.NavigateToLoginEndPoint -> navigateToLoginEndpoint()
             }
         }
     }

--- a/feat/signup/src/main/kotlin/com/team/bottles/feat/signup/SignupScreen.kt
+++ b/feat/signup/src/main/kotlin/com/team/bottles/feat/signup/SignupScreen.kt
@@ -1,32 +1,78 @@
 package com.team.bottles.feat.signup
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
+import android.annotation.SuppressLint
+import android.view.ViewGroup
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.webkit.WebView
+import android.webkit.WebView.setWebContentsDebuggingEnabled
+import android.webkit.WebViewClient
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
 import com.team.bottles.core.designsystem.theme.BottlesTheme
 import com.team.bottles.feat.signup.mvi.SignupIntent
 import com.team.bottles.feat.signup.mvi.SignupUiState
 
+@SuppressLint("SetJavaScriptEnabled")
 @Composable
 fun SignupScreen(
     uiState: SignupUiState,
     onIntent: (SignupIntent) -> Unit,
 ) {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(color = BottlesTheme.color.background.primary)
-            .padding(horizontal = 16.dp),
-        contentAlignment = Alignment.Center
-    ) {
-        // webview 구현
+    val context = LocalContext.current
+    val webView = remember { WebView(context) }
+
+    BackHandler {
+        if (uiState.isWebPageCanGoBack){
+            webView.goBack()
+        }
+        else {
+            onIntent(SignupIntent.ClickWebCloseButton)
+        }
     }
+
+    DisposableEffect(webView) {
+        webView.webViewClient = object : WebViewClient() {
+            override fun doUpdateVisitedHistory(view: WebView?, url: String?, isReload: Boolean) {
+                super.doUpdateVisitedHistory(view, url, isReload)
+
+                onIntent(SignupIntent.LoadWebPage(canGoBack = view?.canGoBack()?: false))
+            }
+        }
+
+        onDispose {
+            webView.destroy()
+        }
+    }
+
+    AndroidView(
+        modifier = Modifier.fillMaxSize(),
+        factory = {
+            webView.apply {
+                layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)
+                settings.domStorageEnabled = true
+                settings.javaScriptEnabled = true
+                setWebContentsDebuggingEnabled(true)
+                loadUrl(BuildConfig.BOTTLES_SIGNUP_URL)
+                addJavascriptInterface(
+                    SignupBridge { webEvent ->
+                        when (webEvent) {
+                            is SignupWebAction.OnToastOpen -> {  }
+                            is SignupWebAction.OnWebViewClose -> onIntent(SignupIntent.ClickWebCloseButton)
+                            is SignupWebAction.OnSignup -> onIntent(SignupIntent.ClickSignupButton(token = webEvent.token))
+                        }
+                    },
+                    SignupBridge.NAME
+                )
+            }
+        }
+    )
 }
 
 @Preview(showBackground = true)
@@ -34,7 +80,7 @@ fun SignupScreen(
 private fun SignupScreenPreview() {
     BottlesTheme {
         SignupScreen(
-            uiState = SignupUiState,
+            uiState = SignupUiState(),
             onIntent = { },
         )
     }

--- a/feat/signup/src/main/kotlin/com/team/bottles/feat/signup/SignupViewModel.kt
+++ b/feat/signup/src/main/kotlin/com/team/bottles/feat/signup/SignupViewModel.kt
@@ -2,6 +2,8 @@ package com.team.bottles.feat.signup
 
 import androidx.lifecycle.SavedStateHandle
 import com.team.bottles.core.common.BaseViewModel
+import com.team.bottles.core.domain.auth.model.Token
+import com.team.bottles.core.domain.auth.usecase.WebViewConnectUseCase
 import com.team.bottles.feat.signup.mvi.SignupIntent
 import com.team.bottles.feat.signup.mvi.SignupSideEffect
 import com.team.bottles.feat.signup.mvi.SignupUiState
@@ -10,20 +12,34 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SignupViewModel @Inject constructor(
-
+    private val webViewConnectUseCase: WebViewConnectUseCase,
     savedStateHandle: SavedStateHandle
 ) : BaseViewModel<SignupUiState, SignupSideEffect, SignupIntent>(savedStateHandle) {
 
     override fun createInitialState(savedStateHandle: SavedStateHandle): SignupUiState =
-        SignupUiState
+        SignupUiState()
 
     override fun handleClientException(throwable: Throwable) {
         TODO("Not yet implemented")
     }
 
     override suspend fun handleIntent(intent: SignupIntent) {
-        TODO("Not yet implemented")
+        when (intent) {
+            is SignupIntent.ClickSignupButton -> signup(token = intent.token)
+            is SignupIntent.ClickWebCloseButton -> navigateToLoginEndPoint()
+            is SignupIntent.LoadWebPage -> reduce { copy(isWebPageCanGoBack = intent.canGoBack) }
+        }
     }
 
+    private fun signup(token: Token) {
+        launch {
+            webViewConnectUseCase.setLocalToken(token = token)
+            postSideEffect(SignupSideEffect.NavigateToSandBeach)
+        }
+    }
+
+    private fun navigateToLoginEndPoint() {
+        postSideEffect(SignupSideEffect.NavigateToLoginEndPoint)
+    }
 
 }

--- a/feat/signup/src/main/kotlin/com/team/bottles/feat/signup/mvi/SignupIntent.kt
+++ b/feat/signup/src/main/kotlin/com/team/bottles/feat/signup/mvi/SignupIntent.kt
@@ -1,12 +1,14 @@
 package com.team.bottles.feat.signup.mvi
 
 import com.team.bottles.core.common.UiIntent
-import com.team.bottles.core.domain.auth.KakaoClientResult
+import com.team.bottles.core.domain.auth.model.Token
 
 sealed interface SignupIntent : UiIntent {
 
-    data object ClickWebBackButton: SignupIntent // webview에서 뒤로가기 버튼 클릭
+    data object ClickWebCloseButton : SignupIntent
 
-    data object ClickWebCompleteButton: SignupIntent // webview에서 확인 버튼 클릭
+    data class ClickSignupButton(val token: Token) : SignupIntent
+
+    data class LoadWebPage(val canGoBack: Boolean) : SignupIntent
 
 }

--- a/feat/signup/src/main/kotlin/com/team/bottles/feat/signup/mvi/SignupSideEffect.kt
+++ b/feat/signup/src/main/kotlin/com/team/bottles/feat/signup/mvi/SignupSideEffect.kt
@@ -2,10 +2,10 @@ package com.team.bottles.feat.signup.mvi
 
 import com.team.bottles.core.common.UiSideEffect
 
-sealed interface SignupSideEffect: UiSideEffect {
+sealed interface SignupSideEffect : UiSideEffect {
 
-    data object NavigateToLogin: SignupSideEffect
+    data object NavigateToLoginEndPoint : SignupSideEffect
 
-    data object NavigateToSandBeach: SignupSideEffect
+    data object NavigateToSandBeach : SignupSideEffect
 
 }

--- a/feat/signup/src/main/kotlin/com/team/bottles/feat/signup/mvi/SignupUiState.kt
+++ b/feat/signup/src/main/kotlin/com/team/bottles/feat/signup/mvi/SignupUiState.kt
@@ -2,4 +2,6 @@ package com.team.bottles.feat.signup.mvi
 
 import com.team.bottles.core.common.UiState
 
-data object SignupUiState : UiState
+data class SignupUiState(
+    val isWebPageCanGoBack: Boolean = false
+) : UiState

--- a/feat/signup/src/main/kotlin/com/team/bottles/feat/signup/navigation/SignupNavigation.kt
+++ b/feat/signup/src/main/kotlin/com/team/bottles/feat/signup/navigation/SignupNavigation.kt
@@ -6,12 +6,12 @@ import androidx.navigation.compose.composable
 import com.team.bottles.feat.signup.SignupRoute
 
 fun NavGraphBuilder.signupScreen(
-    navigateToLogin: () -> Unit,
+    navigateToLoginEndpoint: () -> Unit,
     navigateToSandBeach: () -> Unit
 ) {
     composable<SignupNavigator> {
         SignupRoute(
-            navigateToLogin = navigateToLogin,
+            navigateToLoginEndpoint = navigateToLoginEndpoint,
             navigateToSandBeach = navigateToSandBeach
         )
     }


### PR DESCRIPTION
## 관련 이슈
- #28 

## 작업한 내용
- BaseBridge 정의
- 회원가입 화면 구현
- 시스템 네비에이션 뒤로가기 핸들링 구현
- WebViewConnectUseCase 구현
  - local에 토큰을 주고 받기 위해 사용 (배포 이후 토큰 쌍방향 전달은 빠질 예정)