### PR TITLE
[Fix] 프로필 이미지 다운 샘플링

### DIFF
--- a/core/design-system/src/main/kotlin/com/team/bottles/core/designsystem/components/bars/TopBar.kt
+++ b/core/design-system/src/main/kotlin/com/team/bottles/core/designsystem/components/bars/TopBar.kt
@@ -1,6 +1,5 @@
 package com.team.bottles.core.designsystem.components.bars
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,7 +13,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -29,14 +27,14 @@ fun BottlesTopBar(
     trailingIcon: (@Composable () -> Unit)? = null,
 ) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .height(48.dp)
             .padding(horizontal = 16.dp),
         contentAlignment = Alignment.Center,
     ) {
         Row(
-            modifier = modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = if (leadingIcon == null) Arrangement.End else Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/core/ui/src/main/kotlin/com/team/bottles/core/ui/Loading.kt
+++ b/core/ui/src/main/kotlin/com/team/bottles/core/ui/Loading.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.team.bottles.core.designsystem.theme.BottlesTheme
@@ -18,7 +19,8 @@ fun BottlesLoadingScreen() { // TODO : 로띠 이미지 디자인팀 준비시 �
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(color = Color.Black.copy(alpha = 0.4f)),
+            .background(color = Color.Black.copy(alpha = 0.4f))
+            .pointerInput(Unit) {},
         contentAlignment = Alignment.Center
     ) {
         CircularProgressIndicator(

--- a/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/introduction/IntroductionScreen.kt
+++ b/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/introduction/IntroductionScreen.kt
@@ -2,7 +2,6 @@ package com.team.bottles.feat.profile.introduction
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
@@ -34,6 +33,7 @@ import com.team.bottles.core.designsystem.components.textfield.BottlesLinesMaxLe
 import com.team.bottles.core.designsystem.components.textfield.BottlesTextFieldState
 import com.team.bottles.core.designsystem.modifier.noRippleClickable
 import com.team.bottles.core.designsystem.theme.BottlesTheme
+import com.team.bottles.core.ui.BottlesLoadingScreen
 import com.team.bottles.core.ui.CardProfile
 import com.team.bottles.core.ui.model.UserKeyPoint
 import com.team.bottles.feat.profile.introduction.component.SelectImageCard
@@ -41,7 +41,6 @@ import com.team.bottles.feat.profile.introduction.component.Title
 import com.team.bottles.feat.profile.introduction.mvi.IntroductionIntent
 import com.team.bottles.feat.profile.introduction.mvi.IntroductionStep
 import com.team.bottles.feat.profile.introduction.mvi.IntroductionUiState
-import java.io.File
 
 @Composable
 internal fun IntroductionScreen(
@@ -53,7 +52,7 @@ internal fun IntroductionScreen(
     val isFocused by interactionSource.collectIsFocusedAsState()
     val scrollState = rememberScrollState()
 
-    BackHandler {
+    BackHandler(enabled = !uiState.isLoading) {
         onIntent(IntroductionIntent.ClickBackButton)
     }
 
@@ -61,94 +60,100 @@ internal fun IntroductionScreen(
         onIntent(IntroductionIntent.OnFocusedTextField)
     }
 
-    Scaffold(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(color = BottlesTheme.color.background.primary)
-            .pointerInput(Unit) {
-                detectTapGestures(onTap = {
-                    focusManager.clearFocus()
-                })
-            },
-        topBar = {
-            BottlesTopBar(
-                leadingIcon = {
-                    Icon(
-                        modifier = Modifier.noRippleClickable(
-                            onClick = { onIntent(IntroductionIntent.ClickBackButton) }
-                        ),
-                        painter = painterResource(id = R.drawable.ic_arrow_left_24),
-                        contentDescription = null,
-                        tint = BottlesTheme.color.icon.primary
-                    )
-                }
-            )
-        },
-        bottomBar = {
-            BottlesBottomBar(
-                text = uiState.step.buttonText,
-                onClick = { onIntent(IntroductionIntent.ClickBottomButton) },
-                enabled = uiState.isEnabledWithBottomButton
-            )
-        }
-    ) { innerPadding ->
-        Box(modifier = Modifier.padding(innerPadding)) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(color = BottlesTheme.color.background.primary)
-                    .padding(horizontal = BottlesTheme.spacing.medium)
-                    .verticalScroll(state = scrollState),
-            ) {
-                Spacer(modifier = Modifier.height(height = BottlesTheme.spacing.extraLarge))
-
-                Title(
-                    currentPage = uiState.step.page,
-                    maxPage = IntroductionStep.entries.size,
-                    title = uiState.step.title,
-                    subTitle = uiState.step.subTitle
-                )
-
-                Spacer(modifier = Modifier.height(height = BottlesTheme.spacing.doubleExtraLarge))
-
-                when (uiState.step) {
-                    IntroductionStep.INPUT_INTRODUCTION -> {
-                        BottlesLinesMaxLengthTextField(
-                            value = uiState.introduce,
-                            onValueChange = { text ->
-                                onIntent(IntroductionIntent.ChangeIntroduction(text = text))
-                            },
-                            hint = stringResource(id = R.string.introduction_hint),
-                            maxLength = uiState.maxLength,
-                            state = uiState.introductionTextFiledState,
-                            interactionSource = interactionSource
+    Box {
+        Scaffold(
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) {
+                    detectTapGestures(onTap = {
+                        focusManager.clearFocus()
+                    })
+                },
+            topBar = {
+                BottlesTopBar(
+                    modifier = Modifier.background(color = BottlesTheme.color.background.primary),
+                    leadingIcon = {
+                        Icon(
+                            modifier = Modifier.noRippleClickable(
+                                onClick = { onIntent(IntroductionIntent.ClickBackButton) }
+                            ),
+                            painter = painterResource(id = R.drawable.ic_arrow_left_24),
+                            contentDescription = null,
+                            tint = BottlesTheme.color.icon.primary
                         )
+                    }
+                )
+            },
+            bottomBar = {
+                BottlesBottomBar(
+                    text = uiState.step.buttonText,
+                    onClick = { onIntent(IntroductionIntent.ClickBottomButton) },
+                    enabled = uiState.isEnabledWithBottomButton
+                )
+            }
+        ) { innerPadding ->
+            Box(modifier = Modifier.padding(innerPadding)) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(color = BottlesTheme.color.background.primary)
+                        .padding(horizontal = BottlesTheme.spacing.medium)
+                        .verticalScroll(state = scrollState),
+                ) {
+                    Spacer(modifier = Modifier.height(height = BottlesTheme.spacing.extraLarge))
 
-                        if (uiState.introductionTextFiledState is BottlesTextFieldState.Error) {
-                            Spacer(modifier = Modifier.height(height = BottlesTheme.spacing.doubleExtraSmall))
+                    Title(
+                        currentPage = uiState.step.page,
+                        maxPage = IntroductionStep.entries.size,
+                        title = uiState.step.title,
+                        subTitle = uiState.step.subTitle
+                    )
 
-                            Text(
-                                text = "최소 ${uiState.minLength}글자 이상 작성해주세요",
-                                style = BottlesTheme.typography.caption,
-                                color = BottlesTheme.color.text.errorPrimary
+                    Spacer(modifier = Modifier.height(height = BottlesTheme.spacing.doubleExtraLarge))
+
+                    when (uiState.step) {
+                        IntroductionStep.INPUT_INTRODUCTION -> {
+                            BottlesLinesMaxLengthTextField(
+                                value = uiState.introduce,
+                                onValueChange = { text ->
+                                    onIntent(IntroductionIntent.ChangeIntroduction(text = text))
+                                },
+                                hint = stringResource(id = R.string.introduction_hint),
+                                maxLength = uiState.maxLength,
+                                state = uiState.introductionTextFiledState,
+                                interactionSource = interactionSource
                             )
+
+                            if (uiState.introductionTextFiledState is BottlesTextFieldState.Error) {
+                                Spacer(modifier = Modifier.height(height = BottlesTheme.spacing.doubleExtraSmall))
+
+                                Text(
+                                    text = "최소 ${uiState.minLength}글자 이상 작성해주세요",
+                                    style = BottlesTheme.typography.caption,
+                                    color = BottlesTheme.color.text.errorPrimary
+                                )
+                            }
+
+                            Spacer(modifier = Modifier.height(height = BottlesTheme.spacing.small))
+
+                            CardProfile(keyPoints = uiState.keyPoints)
                         }
 
-                        Spacer(modifier = Modifier.height(height = BottlesTheme.spacing.small))
-
-                        CardProfile(keyPoints = uiState.keyPoints)
+                        IntroductionStep.SELECT_USER_IMAGE -> {
+                            SelectImageCard(
+                                imageFile = uiState.imageFile,
+                                onIntent = onIntent
+                            )
+                        }
                     }
 
-                    IntroductionStep.SELECT_USER_IMAGE -> {
-                        SelectImageCard(
-                            imageFile = uiState.imageFile,
-                            onIntent = onIntent
-                        )
-                    }
+                    Spacer(modifier = Modifier.height(height = BottlesTheme.spacing.extraLarge))
                 }
-
-                Spacer(modifier = Modifier.height(height = BottlesTheme.spacing.extraLarge))
             }
+        }
+
+        if (uiState.isLoading) {
+            BottlesLoadingScreen()
         }
     }
 }
@@ -159,6 +164,7 @@ private fun IntroductionScreenStep1Preview() {
     BottlesTheme {
         IntroductionScreen(
             uiState = IntroductionUiState(
+                isLoading = true,
                 step = IntroductionStep.INPUT_INTRODUCTION,
                 keyPoints = UserKeyPoint.exampleUerKeyPoints(),
                 introduce = "qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",

--- a/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/introduction/IntroductionViewModel.kt
+++ b/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/introduction/IntroductionViewModel.kt
@@ -78,23 +78,19 @@ class IntroductionViewModel @Inject constructor(
                         answer = currentState.introduce)
                 )
             )
-            reduce { copy(step = IntroductionStep.SELECT_USER_IMAGE) }
         }
     }
 
     private fun uploadProfileImage() {
         launch {
-            if (currentState.imageFile == null) {
-                postSideEffect(IntroductionSideEffect.RequireSelectPhoto(toastMessage = "이미지를 선택해주세요."))
-            } else {
-                currentState.imageFile?.let { imageFile ->
-                    uploadProfileImageUseCase(imageFile = imageFile)
-                }
-                postSideEffect(IntroductionSideEffect.CompleteIntroduction(toastMessage = "자기소개 작성을 완료했어요."))
+            reduce { copy(isLoading = true) }
+            currentState.imageFile?.let { imageFile ->
+                uploadProfileImageUseCase(imageFile = imageFile)
             }
+            reduce { copy(isLoading = false) }
+            postSideEffect(IntroductionSideEffect.CompleteIntroduction(toastMessage = "자기소개 작성을 완료했어요."))
         }
     }
-
 
     private fun textChange(text: String) {
         reduce { copy(introduce = text) }

--- a/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/introduction/component/SelecteImage.kt
+++ b/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/introduction/component/SelecteImage.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -30,6 +31,9 @@ import com.team.bottles.core.designsystem.R
 import com.team.bottles.core.designsystem.components.buttons.BottlesIconButton
 import com.team.bottles.core.designsystem.theme.BottlesTheme
 import com.team.bottles.feat.profile.introduction.mvi.IntroductionIntent
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
 
 @SuppressLint("Recycle")
@@ -39,12 +43,15 @@ internal fun SelectImageCard(
     onIntent: (IntroductionIntent) -> Unit
 ) {
     val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
     ) { uri: Uri? ->
         if (uri != null) {
-            val file = uri.toFile(context)
-            onIntent(IntroductionIntent.ClickPhoto(file = file))
+            coroutineScope.launch(Dispatchers.IO) {
+                val file = uri.toFile(context)
+                onIntent(IntroductionIntent.ClickPhoto(file = file))
+            }
         }
     }
 

--- a/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/introduction/mvi/IntroductionUiState.kt
+++ b/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/introduction/mvi/IntroductionUiState.kt
@@ -8,6 +8,7 @@ import java.io.File
 
 @Stable
 data class IntroductionUiState(
+    val isLoading: Boolean = false,
     val step: IntroductionStep = IntroductionStep.INPUT_INTRODUCTION,
     val maxLength: Int = 300,
     val minLength: Int = 50,


### PR DESCRIPTION
## 관련 이슈
- closed #64

## 작업한 내용
- 프로필 이미지 최대 1MB로 제한
- 로딩 스크린시 터치 제어
- 프로필 이미지 보낼때 로딩 화면 추가
