### PR TITLE
[Feat] 핑퐁 화면 당겨서 새로고침 기능 구현

### DIFF
--- a/app/src/main/java/com/team/bottles/di/usecase/BottleUseCaseModule.kt
+++ b/app/src/main/java/com/team/bottles/di/usecase/BottleUseCaseModule.kt
@@ -6,6 +6,8 @@ import com.team.bottles.core.domain.bottle.usecase.GetPingPongDetailUseCase
 import com.team.bottles.core.domain.bottle.usecase.GetPingPongDetailUseCaseImpl
 import com.team.bottles.core.domain.bottle.usecase.GetPingPongListUseCase
 import com.team.bottles.core.domain.bottle.usecase.GetPingPongListUseCaseImpl
+import com.team.bottles.core.domain.bottle.usecase.ReadPingPongDetailUseCase
+import com.team.bottles.core.domain.bottle.usecase.ReadPingPongDetailUseCaseImpl
 import com.team.bottles.core.domain.bottle.usecase.SelectPingPongShareKakaoIdUseCase
 import com.team.bottles.core.domain.bottle.usecase.SelectPingPongShareKakaoIdUseCaseImpl
 import com.team.bottles.core.domain.bottle.usecase.SelectPingPongSharePhotoUseCase
@@ -61,5 +63,11 @@ abstract class BottleUseCaseModule {
     abstract fun bindsGetBottleListUseCase(
         useCaseImpl: GetBottleListUseCaseImpl
     ): GetBottleListUseCase
+
+    @Binds
+    @Singleton
+    abstract fun bindsReadPingPongDetailUseCase(
+        useCaseImpl: ReadPingPongDetailUseCaseImpl
+    ): ReadPingPongDetailUseCase
 
 }

--- a/core/data/src/main/kotlin/com/team/bottles/core/data/repository/BottleRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/team/bottles/core/data/repository/BottleRepositoryImpl.kt
@@ -20,18 +20,16 @@ class BottleRepositoryImpl @Inject constructor(
     override suspend fun loadPingPongList(): PingPongList =
         bottleDataSource.fetchPingPongList().toPingPongResult()
 
-    override suspend fun loadPingPongDetail(bottleId: Int): PingPongDetail {
-        bottleDataSource.updatePingPongReadStatus(bottleId = bottleId)
-        val pingPongDetail = bottleDataSource.fetchPingPongDetail(bottleId = bottleId).toPingPongDetail()
-        return pingPongDetail
-    }
+    override suspend fun loadPingPongDetail(bottleId: Int): PingPongDetail =
+        bottleDataSource.fetchPingPongDetail(bottleId = bottleId).toPingPongDetail()
 
     override suspend fun sendPingPongLetter(bottleId: Int, letterOrder: Int, answer: String) {
         bottleDataSource.sendPingPongLetter(
             bottleId = bottleId,
             request = RegisterLetterRequest(
                 order = letterOrder,
-                answer = answer)
+                answer = answer
+            )
         )
     }
 
@@ -59,5 +57,9 @@ class BottleRepositoryImpl @Inject constructor(
 
     override suspend fun loadBottleList(): ArrivedBottle =
         bottleDataSource.fetchBottleList().toArrivedBottle()
+
+    override suspend fun updatePingPongReadStatus(bottleId: Int) {
+        bottleDataSource.updatePingPongReadStatus(bottleId = bottleId)
+    }
 
 }

--- a/core/domain/src/main/kotlin/com/team/bottles/core/domain/bottle/repository/BottleRepository.kt
+++ b/core/domain/src/main/kotlin/com/team/bottles/core/domain/bottle/repository/BottleRepository.kt
@@ -24,4 +24,6 @@ interface BottleRepository {
 
     suspend fun loadBottleList(): ArrivedBottle
 
+    suspend fun updatePingPongReadStatus(bottleId: Int)
+
 }

--- a/core/domain/src/main/kotlin/com/team/bottles/core/domain/bottle/usecase/ReadPingPongDetailUseCase.kt
+++ b/core/domain/src/main/kotlin/com/team/bottles/core/domain/bottle/usecase/ReadPingPongDetailUseCase.kt
@@ -1,0 +1,20 @@
+package com.team.bottles.core.domain.bottle.usecase
+
+import com.team.bottles.core.domain.bottle.repository.BottleRepository
+import javax.inject.Inject
+
+class ReadPingPongDetailUseCaseImpl @Inject constructor(
+    private val bottleRepository: BottleRepository,
+): ReadPingPongDetailUseCase {
+
+    override suspend fun invoke(bottleId: Int) {
+        bottleRepository.updatePingPongReadStatus(bottleId = bottleId)
+    }
+
+}
+
+interface ReadPingPongDetailUseCase {
+
+    suspend operator fun invoke(bottleId: Int)
+
+}

--- a/feat/ping-pong/src/main/kotlin/com/team/bottles/feat/pingpong/PingPongScreen.kt
+++ b/feat/ping-pong/src/main/kotlin/com/team/bottles/feat/pingpong/PingPongScreen.kt
@@ -1,5 +1,6 @@
 package com.team.bottles.feat.pingpong
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
@@ -55,6 +56,10 @@ internal fun PingPongScreen(
     val pullRefreshState = rememberPullToRefreshState(
         enabled = { uiState.currentTab == PingPongTab.PING_PONG }
     )
+
+    BackHandler {
+        onIntent(PingPongIntent.ClickBackButton)
+    }
 
     LaunchedEffect(uiState.isRefreshing) {
         if (uiState.isRefreshing) {

--- a/feat/ping-pong/src/main/kotlin/com/team/bottles/feat/pingpong/PingPongScreen.kt
+++ b/feat/ping-pong/src/main/kotlin/com/team/bottles/feat/pingpong/PingPongScreen.kt
@@ -217,7 +217,6 @@ internal fun PingPongScreen(
             PullToRefreshContainer(
                 modifier = Modifier.align(Alignment.TopCenter),
                 state = pullRefreshState,
-                //containerColor = Color.Transparent,
             )
         }
     }

--- a/feat/ping-pong/src/main/kotlin/com/team/bottles/feat/pingpong/PingPongScreen.kt
+++ b/feat/ping-pong/src/main/kotlin/com/team/bottles/feat/pingpong/PingPongScreen.kt
@@ -1,5 +1,8 @@
 package com.team.bottles.feat.pingpong
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -7,16 +10,24 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.team.bottles.core.designsystem.R
 import com.team.bottles.core.designsystem.modifier.debounceNoRippleClickable
 import com.team.bottles.core.designsystem.theme.BottlesTheme
+import com.team.bottles.core.domain.bottle.model.PingPongLetter
 import com.team.bottles.core.domain.bottle.model.PingPongMatchStatus
 import com.team.bottles.core.domain.profile.model.UserProfile
 import com.team.bottles.core.ui.BottlesAlertDialog
@@ -26,18 +37,37 @@ import com.team.bottles.feat.pingpong.components.PingPongTopBar
 import com.team.bottles.feat.pingpong.components.introductionContents
 import com.team.bottles.feat.pingpong.components.matchingContents
 import com.team.bottles.feat.pingpong.components.pingPongContents
+import com.team.bottles.feat.pingpong.mvi.PingPongCard
 import com.team.bottles.feat.pingpong.mvi.PingPongIntent
 import com.team.bottles.feat.pingpong.mvi.PingPongTab
 import com.team.bottles.feat.pingpong.mvi.PingPongUiState
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun PingPongScreen(
     uiState: PingPongUiState,
     onIntent: (PingPongIntent) -> Unit
 ) {
+    val focusManager = LocalFocusManager.current
     val introductionTabScrollState = rememberLazyListState()
     val pingPongTabScrollState = rememberLazyListState()
     val matchingScrollState = rememberLazyListState()
+    val pullRefreshState = rememberPullToRefreshState(
+        enabled = { uiState.currentTab == PingPongTab.PING_PONG }
+    )
+
+    LaunchedEffect(uiState.isRefreshing) {
+        if (uiState.isRefreshing) {
+            pullRefreshState.startRefresh()
+            onIntent(PingPongIntent.RefreshPingPong)
+        } else {
+            pullRefreshState.endRefresh()
+        }
+    }
+
+    if (pullRefreshState.isRefreshing && !uiState.isRefreshing) {
+        onIntent(PingPongIntent.ChangeRefreshState)
+    }
 
     if (uiState.showDialog) {
         BottlesAlertDialog(
@@ -51,8 +81,13 @@ internal fun PingPongScreen(
     }
 
     Scaffold(
-        modifier = Modifier.fillMaxSize(),
-        containerColor = BottlesTheme.color.background.primary,
+        modifier = Modifier
+            .fillMaxSize()
+            .pointerInput(Unit) {
+                detectTapGestures(onTap = {
+                    focusManager.clearFocus()
+                })
+            },
         topBar = {
             PingPongTopBar(
                 onClickLeadingIcon = { onIntent(PingPongIntent.ClickBackButton) },
@@ -77,87 +112,113 @@ internal fun PingPongScreen(
             }
         }
     ) { innerPadding ->
-        LazyColumn(
+        Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding),
-            state = when (uiState.currentTab) {
-                PingPongTab.INTRODUCTION -> introductionTabScrollState
-                PingPongTab.PING_PONG -> pingPongTabScrollState
-                PingPongTab.MATCHING -> matchingScrollState
-            },
-            contentPadding = PaddingValues(
-                start = BottlesTheme.spacing.medium,
-                end = BottlesTheme.spacing.medium,
-                top = BottlesTheme.spacing.doubleExtraLarge,
-                bottom = BottlesTheme.spacing.extraLarge
-            ),
-            horizontalAlignment = Alignment.CenterHorizontally
+                .background(color = BottlesTheme.color.background.primary)
+                .padding(innerPadding)
+                .nestedScroll(connection = pullRefreshState.nestedScrollConnection)
         ) {
-            when (uiState.currentTab) {
-                PingPongTab.INTRODUCTION -> {
-                    introductionContents(
-                        isStoppedPingPong = uiState.isStoppedPingPong,
-                        partnerProfile = uiState.partnerProfile,
-                        partnerLetter = uiState.partnerLetter,
-                        partnerKeyPoints = uiState.partnerKeyPoints,
-                        deleteAfterDay = uiState.deleteAfterDay,
-                    )
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                state = when (uiState.currentTab) {
+                    PingPongTab.INTRODUCTION -> introductionTabScrollState
+                    PingPongTab.PING_PONG -> pingPongTabScrollState
+                    PingPongTab.MATCHING -> matchingScrollState
+                },
+                contentPadding = PaddingValues(
+                    start = BottlesTheme.spacing.medium,
+                    end = BottlesTheme.spacing.medium,
+                    top = BottlesTheme.spacing.doubleExtraLarge,
+                    bottom = BottlesTheme.spacing.extraLarge
+                ),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                when (uiState.currentTab) {
+                    PingPongTab.INTRODUCTION -> {
+                        introductionContents(
+                            isStoppedPingPong = uiState.isStoppedPingPong,
+                            partnerProfile = uiState.partnerProfile,
+                            partnerLetter = uiState.partnerLetter,
+                            partnerKeyPoints = uiState.partnerKeyPoints,
+                            deleteAfterDay = uiState.deleteAfterDay,
+                        )
+                    }
+
+                    PingPongTab.PING_PONG -> {
+                        pingPongContents(
+                            pingPongCards = uiState.pingPongCards,
+                            pingPongMatchStatus = uiState.pingPongMatchStatus,
+                            onClickSendLetter = { order, text ->
+                                onIntent(PingPongIntent.ClickSendLetter(order = order, text = text))
+                            },
+                            onValueChange = { order, text ->
+                                onIntent(
+                                    PingPongIntent.OnLetterTextChange(
+                                        order = order,
+                                        text = text
+                                    )
+                                )
+                            },
+                            onClickLetterCard = { order ->
+                                onIntent(PingPongIntent.ClickLetterCard(order = order))
+                            },
+                            onFocusedTextField = { order, isFocused ->
+                                onIntent(
+                                    PingPongIntent.OnFocusedTextField(
+                                        order = order,
+                                        isFocused = isFocused
+                                    )
+                                )
+                            },
+                            onClickLikeSharePhoto = { onIntent(PingPongIntent.ClickLikeSharePhotoButton) },
+                            onClickHateSharePhoto = { onIntent(PingPongIntent.ClickHateSharePhotoButton) },
+                            onClickPhotoCard = { onIntent(PingPongIntent.ClickPhotoCard) },
+                            onClickShareProfilePhoto = { willShare ->
+                                onIntent(PingPongIntent.ClickShareProfilePhoto(willShare = willShare))
+                            },
+                            onClickLikeShareKakaoId = { onIntent(PingPongIntent.ClickLikeShareKakaoIdButton) },
+                            onClickHateShareKakaoId = { onIntent(PingPongIntent.ClickHateShareKakaoIdButton) },
+                            onClickKakaoShareCard = { onIntent(PingPongIntent.ClickKakaoShareCard) },
+                            onClickShareKakaoId = { willMatch ->
+                                onIntent(PingPongIntent.ClickShareKakaoId(willMatch = willMatch))
+                            },
+                        )
+                    }
+
+                    PingPongTab.MATCHING -> {
+                        matchingContents(
+                            matchingResult = uiState.matchingResult,
+                            kakaoId = uiState.partnerKakaoId,
+                            partnerName = uiState.partnerProfile.userName
+                        )
+                    }
                 }
 
-                PingPongTab.PING_PONG -> {
-                    pingPongContents(
-                        pingPongCards = uiState.pingPongCards,
-                        pingPongMatchStatus = uiState.pingPongMatchStatus,
-                        onClickSendLetter = { order, text ->
-                            onIntent(PingPongIntent.ClickSendLetter(order = order, text = text)) },
-                        onValueChange = { order, text ->
-                            onIntent(PingPongIntent.OnLetterTextChange(order = order, text = text)) },
-                        onClickLetterCard = { order ->
-                            onIntent(PingPongIntent.ClickLetterCard(order = order))
-                        },
-                        onFocusedTextField = { order, isFocused ->
-                            onIntent(PingPongIntent.OnFocusedTextField(order = order, isFocused = isFocused))
-                        },
-                        onClickLikeSharePhoto = { onIntent(PingPongIntent.ClickLikeSharePhotoButton) },
-                        onClickHateSharePhoto = { onIntent(PingPongIntent.ClickHateSharePhotoButton) },
-                        onClickPhotoCard = { onIntent(PingPongIntent.ClickPhotoCard) },
-                        onClickShareProfilePhoto = { willShare ->
-                            onIntent(PingPongIntent.ClickShareProfilePhoto(willShare = willShare)) },
-                        onClickLikeShareKakaoId = { onIntent(PingPongIntent.ClickLikeShareKakaoIdButton) },
-                        onClickHateShareKakaoId = { onIntent(PingPongIntent.ClickHateShareKakaoIdButton) },
-                        onClickKakaoShareCard = { onIntent(PingPongIntent.ClickKakaoShareCard) },
-                        onClickShareKakaoId = { willMatch ->
-                            onIntent(PingPongIntent.ClickShareKakaoId(willMatch = willMatch)) },
-                    )
-                }
+                if (uiState.currentTab != PingPongTab.MATCHING) {
+                    item(key = "Finish PingPong Button") {
+                        Spacer(modifier = Modifier.height(height = BottlesTheme.spacing.large))
 
-                PingPongTab.MATCHING -> {
-                    matchingContents(
-                        matchingResult = uiState.matchingResult,
-                        kakaoId = uiState.partnerKakaoId,
-                        partnerName = uiState.partnerProfile.userName
-                    )
+                        Text(
+                            modifier = Modifier
+                                .debounceNoRippleClickable(
+                                    onClick = { onIntent(PingPongIntent.ClickConversationFinishButton) },
+                                    enabled = !uiState.isStoppedPingPong
+                                ),
+                            text = stringResource(id = R.string.conversation_finish),
+                            style = BottlesTheme.typography.subTitle2,
+                            color = if (!uiState.isStoppedPingPong) BottlesTheme.color.text.enabledSecondary
+                            else BottlesTheme.color.text.disabledSecondary
+                        )
+                    }
                 }
             }
 
-            if (uiState.currentTab != PingPongTab.MATCHING) {
-                item(key = "Finish PingPong Button") {
-                    Spacer(modifier = Modifier.height(height = BottlesTheme.spacing.large))
-
-                    Text(
-                        modifier = Modifier
-                            .debounceNoRippleClickable(
-                                onClick = { onIntent(PingPongIntent.ClickConversationFinishButton) },
-                                enabled = !uiState.isStoppedPingPong
-                            ),
-                        text = stringResource(id = R.string.conversation_finish),
-                        style = BottlesTheme.typography.subTitle2,
-                        color = if(!uiState.isStoppedPingPong) BottlesTheme.color.text.enabledSecondary
-                        else BottlesTheme.color.text.disabledSecondary
-                    )
-                }
-            }
+            PullToRefreshContainer(
+                modifier = Modifier.align(Alignment.TopCenter),
+                state = pullRefreshState,
+                //containerColor = Color.Transparent,
+            )
         }
     }
 }
@@ -168,9 +229,16 @@ private fun PingPongScreenPreview() {
     BottlesTheme {
         PingPongScreen(
             uiState = PingPongUiState(
-                currentTab = PingPongTab.PING_PONG,
+                currentTab = PingPongTab.INTRODUCTION,
                 pingPongMatchStatus = PingPongMatchStatus.NONE,
                 partnerProfile = UserProfile.sampleUserProfile(),
+                pingPongCards = listOf(
+                    PingPongCard.Letter(letter = PingPongLetter(order = 0)),
+                    PingPongCard.Letter(letter = PingPongLetter(order = 1)),
+                    PingPongCard.Letter(letter = PingPongLetter(order = 2)),
+                    PingPongCard.Photo(),
+                    PingPongCard.KakaoShare()
+                )
             ),
             onIntent = {}
         )

--- a/feat/ping-pong/src/main/kotlin/com/team/bottles/feat/pingpong/PingPongViewModel.kt
+++ b/feat/ping-pong/src/main/kotlin/com/team/bottles/feat/pingpong/PingPongViewModel.kt
@@ -17,6 +17,7 @@ import com.team.bottles.feat.pingpong.mvi.PingPongTab
 import com.team.bottles.feat.pingpong.mvi.PingPongUiState
 import com.team.bottles.feat.pingpong.mvi.ShareSelectButtonState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import javax.inject.Inject
 
 @HiltViewModel
@@ -60,11 +61,14 @@ class PingPongViewModel @Inject constructor(
             is PingPongIntent.ClickShareKakaoId -> shareKakaoId(willMatch = intent.willMatch)
             is PingPongIntent.ClickHateShareKakaoIdButton -> selectHateShareKakaoIdButton()
             is PingPongIntent.ClickLikeShareKakaoIdButton -> selectLikeShareKakaoIdButton()
+            is PingPongIntent.ChangeRefreshState -> reduce { copy(isRefreshing = true) }
+            is PingPongIntent.RefreshPingPong -> getPingPongDetail()
         }
     }
 
     private fun getPingPongDetail() {
         launch {
+            delay(300L)
             val result = getPingPongDetailUseCase(bottleId = currentState.bottleId)
 
             val pingPongCards = result.letters.map { letter ->
@@ -76,6 +80,7 @@ class PingPongViewModel @Inject constructor(
 
             reduce {
                 copy(
+                    isRefreshing = false,
                     isStoppedPingPong = result.isStopped,
                     deleteAfterDay = result.deleteAfterDays.toInt(),
                     stopUserName = result.stopUserName,

--- a/feat/ping-pong/src/main/kotlin/com/team/bottles/feat/pingpong/PingPongViewModel.kt
+++ b/feat/ping-pong/src/main/kotlin/com/team/bottles/feat/pingpong/PingPongViewModel.kt
@@ -6,6 +6,7 @@ import androidx.navigation.toRoute
 import com.team.bottles.core.common.BaseViewModel
 import com.team.bottles.core.designsystem.components.textfield.BottlesTextFieldState
 import com.team.bottles.core.domain.bottle.usecase.GetPingPongDetailUseCase
+import com.team.bottles.core.domain.bottle.usecase.ReadPingPongDetailUseCase
 import com.team.bottles.core.domain.bottle.usecase.SelectPingPongShareKakaoIdUseCase
 import com.team.bottles.core.domain.bottle.usecase.SelectPingPongSharePhotoUseCase
 import com.team.bottles.core.domain.bottle.usecase.SendPingPongLetterUseCase
@@ -27,10 +28,12 @@ class PingPongViewModel @Inject constructor(
     private val selectPingPongSharePhotoUseCase: SelectPingPongSharePhotoUseCase,
     private val selectPingPongShareKakaoIdUseCase: SelectPingPongShareKakaoIdUseCase,
     private val stopPingPongUseCase: StopPingPongUseCase,
+    private val readPingPongDetailUseCase: ReadPingPongDetailUseCase,
     savedStateHandle: SavedStateHandle
 ) : BaseViewModel<PingPongUiState, PingPongSideEffect, PingPongIntent>(savedStateHandle) {
 
     init {
+        launch { readPingPongDetailUseCase(bottleId = currentState.bottleId) }
         getPingPongDetail()
     }
 

--- a/feat/ping-pong/src/main/kotlin/com/team/bottles/feat/pingpong/components/Topbar.kt
+++ b/feat/ping-pong/src/main/kotlin/com/team/bottles/feat/pingpong/components/Topbar.kt
@@ -1,5 +1,6 @@
 package com.team.bottles.feat.pingpong.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Icon
@@ -27,7 +28,9 @@ internal fun PingPongTopBar(
     currentTab: PingPongTab,
 ) {
     Column(
-        modifier = modifier.fillMaxWidth()
+        modifier = modifier
+            .fillMaxWidth()
+            .background(color = BottlesTheme.color.background.primary)
     ) {
         BottlesTopBar(
             leadingIcon = {

--- a/feat/ping-pong/src/main/kotlin/com/team/bottles/feat/pingpong/mvi/PingPongIntent.kt
+++ b/feat/ping-pong/src/main/kotlin/com/team/bottles/feat/pingpong/mvi/PingPongIntent.kt
@@ -53,4 +53,8 @@ sealed interface PingPongIntent : UiIntent {
 
     data class ClickShareKakaoId(val willMatch: Boolean) : PingPongIntent
 
+    data object RefreshPingPong : PingPongIntent
+
+    data object ChangeRefreshState : PingPongIntent
+
 }

--- a/feat/ping-pong/src/main/kotlin/com/team/bottles/feat/pingpong/mvi/PingPongUiState.kt
+++ b/feat/ping-pong/src/main/kotlin/com/team/bottles/feat/pingpong/mvi/PingPongUiState.kt
@@ -3,8 +3,8 @@ package com.team.bottles.feat.pingpong.mvi
 import androidx.compose.runtime.Stable
 import com.team.bottles.core.common.UiState
 import com.team.bottles.core.designsystem.components.textfield.BottlesTextFieldState
-import com.team.bottles.core.domain.bottle.model.PingPongMatchStatus
 import com.team.bottles.core.domain.bottle.model.PingPongLetter
+import com.team.bottles.core.domain.bottle.model.PingPongMatchStatus
 import com.team.bottles.core.domain.bottle.model.PingPongPhotoStatus
 import com.team.bottles.core.domain.bottle.model.PingPongPhotos
 import com.team.bottles.core.domain.profile.model.UserProfile
@@ -13,6 +13,7 @@ import com.team.bottles.core.ui.model.UserKeyPoint
 
 @Stable
 data class PingPongUiState(
+    val isRefreshing: Boolean = false,
     val bottleId: Int = 0,
     val showDialog: Boolean = false,
     val isStoppedPingPong: Boolean = false,
@@ -22,13 +23,7 @@ data class PingPongUiState(
     val partnerProfile: UserProfile = UserProfile(),
     val partnerKakaoId: String = "",
     val pingPongMatchStatus: PingPongMatchStatus = PingPongMatchStatus.NONE,
-    val pingPongCards: List<PingPongCard> = listOf(
-        PingPongCard.Letter(),
-        PingPongCard.Letter(),
-        PingPongCard.Letter(),
-        PingPongCard.Photo(),
-        PingPongCard.KakaoShare(),
-    )
+    val pingPongCards: List<PingPongCard> = emptyList()
 ) : UiState {
 
     val partnerKeyPoints: List<UserKeyPoint>
@@ -56,44 +51,6 @@ data class PingPongUiState(
             PingPongMatchStatus.MATCH_FAILED -> MatchingResult.FAIL
             else -> MatchingResult.WAITING
         }
-
-    companion object {
-        fun examplePingPongState() : PingPongUiState = PingPongUiState(
-            pingPongCards = listOf(
-                PingPongCard.Letter(
-                    letter = PingPongLetter(
-                        order = 0,
-                        canShow = true,
-                        question = "Q. 첫번째 질문, 1 더하기 1이 2인 이유는?",
-                        otherAnswer = "답변은 짧게 했는데요?",
-                        myAnswer = "vhgvgh",
-                        shouldAnswer = false,
-                        isDone = true
-                    )
-                ),
-                PingPongCard.Letter(
-                    letter = PingPongLetter(
-                        canShow = true,
-                        order = 1,
-                        question = "Q. 두번째 질문, 2 더하기 2가 4인 이유는?",
-                        myAnswer = "",
-                        otherAnswer = "나는 이미 답변을 했어. 너만 하면돼.",
-                        shouldAnswer = true,
-                        isDone = false
-                    )
-                ),
-                PingPongCard.Letter(
-                    letter = PingPongLetter(
-                        canShow = false,
-                        order = 2,
-                        question = "Q. 세번째 질문, 1 곱하기 1이 1인 이유는?"
-                    )
-                ),
-                PingPongCard.Photo(),
-                PingPongCard.KakaoShare()
-            )
-        )
-    }
 
 }
 


### PR DESCRIPTION
## 관련 이슈
- closed #73 

## 작업한 내용
- PingPongScreen 의 [가치관 문답] 탭에서 당겨서 새로고침 기능 구현
- 핑퐁 읽음 처리 UseCase 분리
- 시스템 네비게이션으로 뒤로 가기시 해당 핑퐁 읽음 처리 안되던 오류 수정
