### PR TITLE
[Feat] FCM 기능 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,10 +84,6 @@ dependencies {
     // Kakao
     implementation(libs.kakao.login)
 
-    // Google
-    implementation(platform(libs.firebase.bom))
-    implementation(libs.firebase.analytics)
-
     // Test
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
 
     <application
@@ -15,6 +16,26 @@
         android:theme="@style/Theme.Bottles"
         android:hardwareAccelerated="true"
         tools:ignore="DiscouragedApi">
+
+        <service
+            android:name=".BottleFcmService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/bottle_app_icon" />
+
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@color/black" />
+
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="@string/fcm_channel_id" />
 
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/team/bottles/BottleFcmService.kt
+++ b/app/src/main/java/com/team/bottles/BottleFcmService.kt
@@ -1,0 +1,77 @@
+package com.team.bottles
+
+import android.Manifest
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.BitmapFactory
+import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import com.team.bottles.core.datastore.datasource.TokenDataSource
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+@AndroidEntryPoint
+internal class BottleFcmService : FirebaseMessagingService() {
+
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    @Inject
+    lateinit var tokenDataSource: TokenDataSource
+
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+
+        scope.launch {
+            tokenDataSource.setFcmDeviceToken(fcmDeviceToken = token)
+        }
+    }
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        super.onMessageReceived(message)
+
+        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+            return
+        }
+        val notification = message.notification ?: return
+
+        val intent = Intent(applicationContext, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+
+        val pendingIntent = PendingIntent.getActivity(
+            applicationContext,
+            UUID.randomUUID().hashCode(),
+            intent,
+            PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val builder = NotificationCompat.Builder(applicationContext, getString(R.string.fcm_channel_id))
+            .setSmallIcon(R.drawable.bottle_app_icon)
+            .setLargeIcon(BitmapFactory.decodeResource(resources, R.drawable.bottle_app_icon))
+            .setContentTitle(notification.title)
+            .setContentText(notification.body)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+
+        NotificationManagerCompat.from(this).notify(
+            UUID.randomUUID().hashCode(),
+            builder.build()
+        )
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scope.cancel()
+    }
+
+}

--- a/app/src/main/java/com/team/bottles/MainActivity.kt
+++ b/app/src/main/java/com/team/bottles/MainActivity.kt
@@ -1,9 +1,13 @@
 package com.team.bottles
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import com.google.android.gms.tasks.OnCompleteListener
 import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.messaging.FirebaseMessaging
 import com.team.bottles.core.designsystem.theme.BottlesTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -16,6 +20,8 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         firebaseAnalytics = FirebaseAnalytics.getInstance(this)
+        createNotificationChannel()
+        initializeFcm()
 
         setContent {
             BottlesTheme {
@@ -23,4 +29,29 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
+
+    private fun createNotificationChannel() {
+        val notificationManager = applicationContext.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        val channelId = getString(R.string.fcm_channel_id)
+        val channelName = getString(R.string.fcm_channel_name)
+        val notificationChannel = NotificationChannel(
+            channelId,
+            channelName,
+            NotificationManager.IMPORTANCE_HIGH
+        )
+
+        notificationManager.createNotificationChannel(notificationChannel)
+    }
+
+    private fun initializeFcm() {
+        FirebaseMessaging.getInstance().token.addOnCompleteListener(
+            OnCompleteListener { task ->
+                if (!task.isSuccessful) {
+                    return@OnCompleteListener
+                }
+                task.result
+            }
+        )
+    }
+
 }

--- a/app/src/main/res/values/string.xml
+++ b/app/src/main/res/values/string.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="fcm_channel_id">fcm_channel_id</string>
+    <string name="fcm_channel_name">fcm_channel_name</string>
+</resources>

--- a/build-logic/src/main/kotlin/AndroidFirebaseConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidFirebaseConventionPlugin.kt
@@ -15,6 +15,7 @@ class AndroidFirebaseConventionPlugin : Plugin<Project> {
                 add("implementation", platform(libs.findLibrary("firebase.bom").get()))
                 add("implementation", libs.findLibrary("firebase.analytics").get())
                 add("implementation", libs.findLibrary("firebase.crashlytics").get())
+                add("implementation", libs.findLibrary("firebase.messaging").get())
             }
         }
     }

--- a/core/data/src/main/kotlin/com/team/bottles/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/team/bottles/core/data/repository/AuthRepositoryImpl.kt
@@ -16,7 +16,10 @@ class AuthRepositoryImpl @Inject constructor(
 
     override suspend fun kakaoLogin(accessToken: String): AuthResult =
         authDataSource.authenticateWithKakao(
-            request = KakaoSignInUpRequest(code = accessToken)
+            request = KakaoSignInUpRequest(
+                code = accessToken,
+                fcmDeviceToken = tokenDataSource.getFcmDeviceToken()
+            )
         ).also { response ->
             tokenDataSource.setAccessToken(response.accessToken)
             tokenDataSource.setRefreshToken(response.refreshToken)

--- a/core/datastore/src/main/java/com/team/bottles/core/datastore/datasource/TokenDataSource.kt
+++ b/core/datastore/src/main/java/com/team/bottles/core/datastore/datasource/TokenDataSource.kt
@@ -6,9 +6,13 @@ interface TokenDataSource {
 
     suspend fun setRefreshToken(refreshToken: String)
 
+    suspend fun setFcmDeviceToken(fcmDeviceToken: String)
+
     suspend fun getAccessToken(): String
 
     suspend fun getRefreshToken(): String
+
+    suspend fun getFcmDeviceToken(): String
 
     suspend fun clear()
 

--- a/core/datastore/src/main/java/com/team/bottles/core/datastore/datasource/TokenDataSourceImpl.kt
+++ b/core/datastore/src/main/java/com/team/bottles/core/datastore/datasource/TokenDataSourceImpl.kt
@@ -26,6 +26,14 @@ class TokenDataSourceImpl @Inject constructor(
         }
     }
 
+    override suspend fun setFcmDeviceToken(fcmDeviceToken: String) {
+        tokenPreferences.updateData { preferences ->
+            preferences.toBuilder()
+                .setFcmDeviceToken(fcmDeviceToken)
+                .build()
+        }
+    }
+
     override suspend fun getAccessToken(): String =
         tokenPreferences.data.map { preferences ->
             preferences.accessToken
@@ -34,6 +42,11 @@ class TokenDataSourceImpl @Inject constructor(
     override suspend fun getRefreshToken(): String =
         tokenPreferences.data.map { preferences ->
             preferences.refreshToken
+        }.first()
+
+    override suspend fun getFcmDeviceToken(): String =
+        tokenPreferences.data.map { preferences ->
+            preferences.fcmDeviceToken
         }.first()
 
     override suspend fun clear() {

--- a/core/datastore/src/main/proto/token_preferences.proto
+++ b/core/datastore/src/main/proto/token_preferences.proto
@@ -6,4 +6,5 @@ option java_multiple_files = true;
 message TokenPreferences {
     string access_token = 1;
     string refresh_token = 2;
+    string fcm_device_token = 3;
 }

--- a/core/network/src/main/kotlin/com/team/bottles/network/api/AuthService.kt
+++ b/core/network/src/main/kotlin/com/team/bottles/network/api/AuthService.kt
@@ -2,6 +2,7 @@ package com.team.bottles.network.api
 
 import com.team.bottles.network.dto.auth.request.AuthSmsRequest
 import com.team.bottles.network.dto.auth.request.KakaoSignInUpRequest
+import com.team.bottles.network.dto.auth.request.ReissueTokenRequest
 import com.team.bottles.network.dto.auth.request.SignUpRequest
 import com.team.bottles.network.dto.auth.request.SmsSignInRequest
 import com.team.bottles.network.dto.auth.response.KakaoSignInUpResponse
@@ -19,7 +20,8 @@ interface AuthService {
 
     @POST("/api/v1/auth/refresh")
     suspend fun refresh(
-        @Header("Authorization") refreshToken: String
+        @Header("Authorization") refreshToken: String,
+        @Body reissueTokenRequest: ReissueTokenRequest,
     ): TokensResponse
 
     @POST("/api/v1/auth/logout")

--- a/core/network/src/main/kotlin/com/team/bottles/network/datasource/AuthDataSource.kt
+++ b/core/network/src/main/kotlin/com/team/bottles/network/datasource/AuthDataSource.kt
@@ -2,6 +2,7 @@ package com.team.bottles.network.datasource
 
 import com.team.bottles.network.dto.auth.request.AuthSmsRequest
 import com.team.bottles.network.dto.auth.request.KakaoSignInUpRequest
+import com.team.bottles.network.dto.auth.request.ReissueTokenRequest
 import com.team.bottles.network.dto.auth.request.SignUpRequest
 import com.team.bottles.network.dto.auth.request.SmsSignInRequest
 import com.team.bottles.network.dto.auth.response.KakaoSignInUpResponse
@@ -14,7 +15,8 @@ interface AuthDataSource {
     ): KakaoSignInUpResponse
 
     suspend fun refreshAccessToken(
-        refreshToken: String
+        refreshToken: String,
+        request: ReissueTokenRequest
     ): Result<TokensResponse>
 
     suspend fun signup(

--- a/core/network/src/main/kotlin/com/team/bottles/network/datasource/AuthDataSourceImpl.kt
+++ b/core/network/src/main/kotlin/com/team/bottles/network/datasource/AuthDataSourceImpl.kt
@@ -3,6 +3,7 @@ package com.team.bottles.network.datasource
 import com.team.bottles.network.api.AuthService
 import com.team.bottles.network.dto.auth.request.AuthSmsRequest
 import com.team.bottles.network.dto.auth.request.KakaoSignInUpRequest
+import com.team.bottles.network.dto.auth.request.ReissueTokenRequest
 import com.team.bottles.network.dto.auth.request.SignUpRequest
 import com.team.bottles.network.dto.auth.request.SmsSignInRequest
 import com.team.bottles.network.dto.auth.response.KakaoSignInUpResponse
@@ -16,8 +17,8 @@ class AuthDataSourceImpl @Inject constructor(
     override suspend fun authenticateWithKakao(request: KakaoSignInUpRequest): KakaoSignInUpResponse =
         authService.loginWithKakao(kakaoSignInUpRequest = request)
 
-    override suspend fun refreshAccessToken(refreshToken: String): Result<TokensResponse> =
-        runCatching { authService.refresh(refreshToken = "$TOKEN_TYPE $refreshToken") }
+    override suspend fun refreshAccessToken(refreshToken: String, request: ReissueTokenRequest): Result<TokensResponse> =
+        runCatching { authService.refresh(refreshToken = "$TOKEN_TYPE $refreshToken", reissueTokenRequest = request) }
 
     override suspend fun signup(request: SignUpRequest): TokensResponse =
         authService.signup(singUpRequest = request)

--- a/core/network/src/main/kotlin/com/team/bottles/network/dto/auth/request/KakaoSignInUpRequest.kt
+++ b/core/network/src/main/kotlin/com/team/bottles/network/dto/auth/request/KakaoSignInUpRequest.kt
@@ -5,5 +5,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class KakaoSignInUpRequest(
-    @SerialName("code") val code: String
+    @SerialName("code") val code: String,
+    @SerialName("fcmDeviceToken") val fcmDeviceToken: String
 )

--- a/core/network/src/main/kotlin/com/team/bottles/network/dto/auth/request/ReissueTokenRequest.kt
+++ b/core/network/src/main/kotlin/com/team/bottles/network/dto/auth/request/ReissueTokenRequest.kt
@@ -1,0 +1,9 @@
+package com.team.bottles.network.dto.auth.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ReissueTokenRequest(
+    @SerialName("fcmDeviceToken") val fcmDeviceToken: String
+)

--- a/core/network/src/main/kotlin/com/team/bottles/network/interceptor/AuthAuthenticator.kt
+++ b/core/network/src/main/kotlin/com/team/bottles/network/interceptor/AuthAuthenticator.kt
@@ -2,6 +2,7 @@ package com.team.bottles.network.interceptor
 
 import com.team.bottles.core.datastore.datasource.TokenDataSource
 import com.team.bottles.network.datasource.AuthDataSource
+import com.team.bottles.network.dto.auth.request.ReissueTokenRequest
 import kotlinx.coroutines.runBlocking
 import okhttp3.Authenticator
 import okhttp3.Request
@@ -24,7 +25,14 @@ internal class AuthAuthenticator @Inject constructor(
 
     private suspend fun getNewAccessToken(): String? {
         val currentRefreshToken = tokenDataSource.getRefreshToken()
-        val response = authDataSource.refreshAccessToken(refreshToken = currentRefreshToken).getOrNull()
+        val fcmDeviceToken = tokenDataSource.getFcmDeviceToken()
+
+        val response = authDataSource.refreshAccessToken(
+            refreshToken = currentRefreshToken,
+            request = ReissueTokenRequest(
+                fcmDeviceToken = fcmDeviceToken
+            )
+        ).getOrNull()
 
         if (response != null) {
             tokenDataSource.setAccessToken(accessToken = response.accessToken)

--- a/feat/sandbeach/src/main/kotlin/com/team/bottles/feat/sandbeach/SandBeachRoute.kt
+++ b/feat/sandbeach/src/main/kotlin/com/team/bottles/feat/sandbeach/SandBeachRoute.kt
@@ -1,12 +1,23 @@
 package com.team.bottles.feat.sandbeach
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.team.bottles.feat.sandbeach.mvi.SandBeachSideEffect
 
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
 @Composable
 internal fun SandBeachRoute(
     viewModel: SandBeachViewModel = hiltViewModel(),
@@ -15,6 +26,26 @@ internal fun SandBeachRoute(
     navigateToBottleBox: () -> Unit,
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val notificationPermissionGranted =
+        remember {
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+        }
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            Toast.makeText(context, "동의했음", Toast.LENGTH_SHORT).show()
+        } else {
+            Toast.makeText(context, "동의안함", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    LaunchedEffect(notificationPermissionGranted) {
+        if (!notificationPermissionGranted) {
+            permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
 
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { sideEffect ->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -137,6 +137,7 @@ kakao-login = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakao-
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
+firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
 
 # blur-effect
 compose-cloudy = { group = "com.github.skydoves", name = "cloudy", version.ref = "cloudy" }


### PR DESCRIPTION
## 관련 이슈
- closed #62 

## 작업한 내용
- FCM 푸쉬 알림 기능 구현
- 푸쉬 알림 클릭시 액티비티 떠있으면 상태 유지, 아닐시 액티비티 실행
- 토큰 재발행시 FCM 토큰 전달
- 카카오 로그인시 FCM 토큰 전달
- 모래사장 화면 알림 권한 획득 로직 추가
- FCM 토큰 로컬 저장