### PR TITLE
[Feat] Timber 적용 및 FCM 토큰 업데이트 대응

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,7 +62,6 @@ dependencies {
     implementation(projects.core.designSystem)
     implementation(projects.core.data)
     implementation(projects.core.domain)
-    implementation(projects.core.datastore)
     implementation(projects.core.ui)
     implementation(projects.core.navigator)
     implementation(projects.core.common)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,6 +84,9 @@ dependencies {
     // Kakao
     implementation(libs.kakao.login)
 
+    // Timber
+    implementation(libs.jakewharton.timber)
+
     // Test
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/team/bottles/BottleFcmService.kt
+++ b/app/src/main/java/com/team/bottles/BottleFcmService.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.util.UUID
 import javax.inject.Inject
 
@@ -30,6 +31,8 @@ internal class BottleFcmService : FirebaseMessagingService() {
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
+
+        Timber.tag("FCM").d("On New FCM Token >> $token")
 
         scope.launch {
             tokenDataSource.setFcmDeviceToken(fcmDeviceToken = token)

--- a/app/src/main/java/com/team/bottles/BottleFcmService.kt
+++ b/app/src/main/java/com/team/bottles/BottleFcmService.kt
@@ -10,7 +10,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
-import com.team.bottles.core.datastore.datasource.TokenDataSource
+import com.team.bottles.core.domain.auth.repository.AuthRepository
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -27,7 +27,7 @@ internal class BottleFcmService : FirebaseMessagingService() {
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     @Inject
-    lateinit var tokenDataSource: TokenDataSource
+    lateinit var authRepository: AuthRepository
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
@@ -35,7 +35,7 @@ internal class BottleFcmService : FirebaseMessagingService() {
         Timber.tag("FCM").d("On New FCM Token >> $token")
 
         scope.launch {
-            tokenDataSource.setFcmDeviceToken(fcmDeviceToken = token)
+            authRepository.updateLocalFcmToken(fcmToken = token)
         }
     }
 

--- a/app/src/main/java/com/team/bottles/BottlesApplication.kt
+++ b/app/src/main/java/com/team/bottles/BottlesApplication.kt
@@ -3,6 +3,7 @@ package com.team.bottles
 import android.app.Application
 import com.kakao.sdk.common.KakaoSdk
 import dagger.hilt.android.HiltAndroidApp
+import timber.log.Timber
 
 @HiltAndroidApp
 class BottlesApplication: Application() {
@@ -10,11 +11,18 @@ class BottlesApplication: Application() {
     override fun onCreate() {
         super.onCreate()
 
+        initTimber()
         initKakaoLogin()
     }
 
     private fun initKakaoLogin() {
         KakaoSdk.init(this, BuildConfig.KAKAO_NATIVE_APP_KEY)
+    }
+
+    private fun initTimber() {
+        if(BuildConfig.DEBUG){
+            Timber.plant(Timber.DebugTree())
+        }
     }
 
 }

--- a/app/src/main/java/com/team/bottles/MainActivity.kt
+++ b/app/src/main/java/com/team/bottles/MainActivity.kt
@@ -10,6 +10,7 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.messaging.FirebaseMessaging
 import com.team.bottles.core.designsystem.theme.BottlesTheme
 import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -47,9 +48,11 @@ class MainActivity : ComponentActivity() {
         FirebaseMessaging.getInstance().token.addOnCompleteListener(
             OnCompleteListener { task ->
                 if (!task.isSuccessful) {
+                    Timber.tag("FCM").d("Fail To Get FCM Instance")
                     return@OnCompleteListener
                 }
-                task.result
+                val result = task.result
+                Timber.tag("FCM").d("Success FCM Instance >> $result")
             }
         )
     }

--- a/app/src/main/java/com/team/bottles/MainActivity.kt
+++ b/app/src/main/java/com/team/bottles/MainActivity.kt
@@ -5,17 +5,25 @@ import android.app.NotificationManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.lifecycle.lifecycleScope
 import com.google.android.gms.tasks.OnCompleteListener
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.messaging.FirebaseMessaging
 import com.team.bottles.core.designsystem.theme.BottlesTheme
+import com.team.bottles.core.domain.auth.repository.AuthRepository
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import timber.log.Timber
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
     private lateinit var firebaseAnalytics: FirebaseAnalytics
+
+    @Inject
+    lateinit var authRepository: AuthRepository
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -31,8 +39,16 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        lifecycleScope.launch(Dispatchers.IO) {
+            authRepository.updateFcmTokenToServer()
+        }
+    }
+
     private fun createNotificationChannel() {
-        val notificationManager = applicationContext.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        val notificationManager =
+            applicationContext.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         val channelId = getString(R.string.fcm_channel_id)
         val channelName = getString(R.string.fcm_channel_name)
         val notificationChannel = NotificationChannel(
@@ -52,7 +68,7 @@ class MainActivity : ComponentActivity() {
                     return@OnCompleteListener
                 }
                 val result = task.result
-                Timber.tag("FCM").d("Success FCM Instance >> $result")
+                Timber.tag("FCM").d("Success To Get FCM Instance >> $result")
             }
         )
     }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -11,4 +11,6 @@ dependencies {
     implementation(projects.core.domain)
     implementation(projects.core.network)
     implementation(projects.core.datastore)
+
+    implementation(libs.jakewharton.timber)
 }

--- a/core/datastore/src/main/java/com/team/bottles/core/datastore/datasource/TokenDataSource.kt
+++ b/core/datastore/src/main/java/com/team/bottles/core/datastore/datasource/TokenDataSource.kt
@@ -8,12 +8,18 @@ interface TokenDataSource {
 
     suspend fun setFcmDeviceToken(fcmDeviceToken: String)
 
+    suspend fun setIsUpdatedFcmToken(isUpdated: Boolean)
+
     suspend fun getAccessToken(): String
 
     suspend fun getRefreshToken(): String
 
     suspend fun getFcmDeviceToken(): String
 
-    suspend fun clear()
+    suspend fun getIsUpdatedFcmToken(): Boolean
+
+    suspend fun clearAccessTokenAndRefreshToken()
+
+    suspend fun clearIsUpdatedFcmToken()
 
 }

--- a/core/datastore/src/main/java/com/team/bottles/core/datastore/datasource/TokenDataSourceImpl.kt
+++ b/core/datastore/src/main/java/com/team/bottles/core/datastore/datasource/TokenDataSourceImpl.kt
@@ -34,6 +34,14 @@ class TokenDataSourceImpl @Inject constructor(
         }
     }
 
+    override suspend fun setIsUpdatedFcmToken(isUpdated: Boolean) {
+        tokenPreferences.updateData { preferences ->
+            preferences.toBuilder()
+                .setIsUpdatedFcmToken(isUpdated)
+                .build()
+        }
+    }
+
     override suspend fun getAccessToken(): String =
         tokenPreferences.data.map { preferences ->
             preferences.accessToken
@@ -49,10 +57,24 @@ class TokenDataSourceImpl @Inject constructor(
             preferences.fcmDeviceToken
         }.first()
 
-    override suspend fun clear() {
+    override suspend fun getIsUpdatedFcmToken(): Boolean =
+        tokenPreferences.data.map { preferences ->
+            preferences.isUpdatedFcmToken
+        }.first()
+
+    override suspend fun clearAccessTokenAndRefreshToken() {
         tokenPreferences.updateData { preferences ->
             preferences.toBuilder()
-                .clear()
+                .clearAccessToken()
+                .clearRefreshToken()
+                .build()
+        }
+    }
+
+    override suspend fun clearIsUpdatedFcmToken() {
+        tokenPreferences.updateData { preferences ->
+            preferences.toBuilder()
+                .clearIsUpdatedFcmToken()
                 .build()
         }
     }

--- a/core/datastore/src/main/proto/token_preferences.proto
+++ b/core/datastore/src/main/proto/token_preferences.proto
@@ -7,4 +7,5 @@ message TokenPreferences {
     string access_token = 1;
     string refresh_token = 2;
     string fcm_device_token = 3;
+    bool is_updated_fcm_token = 4;
 }

--- a/core/domain/src/main/kotlin/com/team/bottles/core/domain/auth/repository/AuthRepository.kt
+++ b/core/domain/src/main/kotlin/com/team/bottles/core/domain/auth/repository/AuthRepository.kt
@@ -15,4 +15,8 @@ interface AuthRepository {
 
     suspend fun updateLocalToken(token: Token)
 
+    suspend fun updateLocalFcmToken(fcmToken: String)
+
+    suspend fun updateFcmTokenToServer()
+
 }

--- a/core/network/src/main/kotlin/com/team/bottles/network/api/AuthService.kt
+++ b/core/network/src/main/kotlin/com/team/bottles/network/api/AuthService.kt
@@ -1,6 +1,7 @@
 package com.team.bottles.network.api
 
 import com.team.bottles.network.dto.auth.request.AuthSmsRequest
+import com.team.bottles.network.dto.auth.request.FcmUpdateRequest
 import com.team.bottles.network.dto.auth.request.KakaoSignInUpRequest
 import com.team.bottles.network.dto.auth.request.ReissueTokenRequest
 import com.team.bottles.network.dto.auth.request.SignUpRequest
@@ -52,6 +53,12 @@ interface AuthService {
     @POST("/api/v1/auth/sms/send/check")
     suspend fun checkSendSms(
         @Body authSmsRequest: AuthSmsRequest
+    )
+
+    @POST("/api/v1/auth/fcm")
+    suspend fun postUpdatedFcmToken(
+        @Header("Authorization") accessToken: String,
+        @Body fcmUpdateRequest: FcmUpdateRequest
     )
 
 }

--- a/core/network/src/main/kotlin/com/team/bottles/network/datasource/AuthDataSource.kt
+++ b/core/network/src/main/kotlin/com/team/bottles/network/datasource/AuthDataSource.kt
@@ -1,6 +1,7 @@
 package com.team.bottles.network.datasource
 
 import com.team.bottles.network.dto.auth.request.AuthSmsRequest
+import com.team.bottles.network.dto.auth.request.FcmUpdateRequest
 import com.team.bottles.network.dto.auth.request.KakaoSignInUpRequest
 import com.team.bottles.network.dto.auth.request.ReissueTokenRequest
 import com.team.bottles.network.dto.auth.request.SignUpRequest
@@ -34,5 +35,10 @@ interface AuthDataSource {
     suspend fun getSmsCode(request: AuthSmsRequest)
 
     suspend fun checkSendSms(request: AuthSmsRequest)
+
+    suspend fun updateFcmToken(
+        accessToken: String,
+        request: FcmUpdateRequest
+    )
 
 }

--- a/core/network/src/main/kotlin/com/team/bottles/network/datasource/AuthDataSourceImpl.kt
+++ b/core/network/src/main/kotlin/com/team/bottles/network/datasource/AuthDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.team.bottles.network.datasource
 
 import com.team.bottles.network.api.AuthService
 import com.team.bottles.network.dto.auth.request.AuthSmsRequest
+import com.team.bottles.network.dto.auth.request.FcmUpdateRequest
 import com.team.bottles.network.dto.auth.request.KakaoSignInUpRequest
 import com.team.bottles.network.dto.auth.request.ReissueTokenRequest
 import com.team.bottles.network.dto.auth.request.SignUpRequest
@@ -40,6 +41,10 @@ class AuthDataSourceImpl @Inject constructor(
 
     override suspend fun checkSendSms(request: AuthSmsRequest) {
         authService.checkSendSms(authSmsRequest = request)
+    }
+
+    override suspend fun updateFcmToken(accessToken: String, request: FcmUpdateRequest) {
+        authService.postUpdatedFcmToken(accessToken = "$TOKEN_TYPE $accessToken", fcmUpdateRequest = request)
     }
 
     companion object {

--- a/core/network/src/main/kotlin/com/team/bottles/network/dto/auth/request/FcmUpdateRequest.kt
+++ b/core/network/src/main/kotlin/com/team/bottles/network/dto/auth/request/FcmUpdateRequest.kt
@@ -1,0 +1,9 @@
+package com.team.bottles.network.dto.auth.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FcmUpdateRequest(
+    @SerialName("fcmToken") val fcmToken: String
+)

--- a/core/network/src/main/kotlin/com/team/bottles/network/interceptor/AuthAuthenticator.kt
+++ b/core/network/src/main/kotlin/com/team/bottles/network/interceptor/AuthAuthenticator.kt
@@ -42,7 +42,7 @@ internal class AuthAuthenticator @Inject constructor(
         } else {
             val accessToken = tokenDataSource.getAccessToken()
             authDataSource.logout(accessToken = accessToken)
-            tokenDataSource.clear()
+            tokenDataSource.clearAccessTokenAndRefreshToken()
             return null
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,6 +65,9 @@ airbnb-lottie = "6.4.0"
 # kakao
 kakao-login = "2.14.0"
 
+# timber
+timberVersion = "5.0.1"
+
 # test
 junit = "4.13.2"
 androidx-junit-version = "1.2.1"
@@ -141,6 +144,9 @@ firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging
 
 # blur-effect
 compose-cloudy = { group = "com.github.skydoves", name = "cloudy", version.ref = "cloudy" }
+
+# timber
+jakewharton-timber = { module = "com.jakewharton.timber:timber", version.ref = "timberVersion" }
 
 # androidx test
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidx-test-core" }


### PR DESCRIPTION
## 관련 이슈
- closed #79 
- closed #80 

## 작업한 내용

- Timber 추가 및 디버그 모드일 때에만 적용
- FCM 토큰 정책 대응
 - 로그인 상태의 유저만 FCM 토큰을 서버로 POST
 - FCM 토큰 갱신시 Activity의 `onResume` 에서 갱신된 토큰 서버로 전달 (단, 로그인 상태일 때 + 토큰이 갱싱된 상태일 때에 전달)