### PR TITLE
[Feat] 데이터 스토어에 FCM 토큰이 없을 경우 저장하는 로직 구현

### DIFF
--- a/app/src/main/java/com/team/bottles/MainActivity.kt
+++ b/app/src/main/java/com/team/bottles/MainActivity.kt
@@ -68,6 +68,12 @@ class MainActivity : ComponentActivity() {
                     return@OnCompleteListener
                 }
                 val result = task.result
+                lifecycleScope.launch(Dispatchers.IO) {
+                    val savedLocalToken = authRepository.getSavedLocalFcmToken()
+                    if (savedLocalToken.isEmpty() || savedLocalToken != result) {
+                        authRepository.updateLocalFcmToken(fcmToken = result)
+                    }
+                }
                 Timber.tag("FCM").d("Success To Get FCM Instance >> $result")
             }
         )

--- a/core/data/src/main/kotlin/com/team/bottles/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/team/bottles/core/data/repository/AuthRepositoryImpl.kt
@@ -70,4 +70,7 @@ class AuthRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getSavedLocalFcmToken(): String =
+        tokenDataSource.getFcmDeviceToken()
+
 }

--- a/core/domain/src/main/kotlin/com/team/bottles/core/domain/auth/repository/AuthRepository.kt
+++ b/core/domain/src/main/kotlin/com/team/bottles/core/domain/auth/repository/AuthRepository.kt
@@ -19,4 +19,6 @@ interface AuthRepository {
 
     suspend fun updateFcmTokenToServer()
 
+    suspend fun getSavedLocalFcmToken(): String
+
 }


### PR DESCRIPTION
## 작업한 내용
- 데이터 스토어에 FCM 토큰이 없을 경우 `onCreate`에서 토큰 저장 로직 구현
  - 이전 0.9.4-beta 버전에서 로그아웃/회원탈퇴 시 모든 토큰을 지우는 로직(`tokenDataSource.clear()`)으로 인해 FCM 토큰이 삭제되었을 가능성을 고려한 로직 추가
