### PR TITLE
[Fix] 알림 권한 로직 변경

### DIFF
--- a/app/src/main/java/com/team/bottles/di/usecase/UserUseCaseModule.kt
+++ b/app/src/main/java/com/team/bottles/di/usecase/UserUseCaseModule.kt
@@ -2,6 +2,8 @@ package com.team.bottles.di.usecase
 
 import com.team.bottles.core.domain.user.usecase.GetContactsUseCase
 import com.team.bottles.core.domain.user.usecase.GetContactsUseCaseImpl
+import com.team.bottles.core.domain.user.usecase.GetNotificationPermissionStatusUseCase
+import com.team.bottles.core.domain.user.usecase.GetNotificationPermissionStatusUseCaseImpl
 import com.team.bottles.core.domain.user.usecase.GetSettingNotificationsUseCase
 import com.team.bottles.core.domain.user.usecase.GetSettingNotificationsUseCaseImpl
 import com.team.bottles.core.domain.user.usecase.ReportUserUseCase
@@ -51,5 +53,10 @@ abstract class UserUseCaseModule {
     abstract fun bindsUpdateActivateMatchingUseCase(
         useCaseImpl: UpdateActivateMatchingUseCaseImpl
     ): UpdateActivateMatchingUseCase
+
+    @Binds
+    abstract fun bindsGetNotificationPermissionStatusUseCase(
+        useCaseImpl: GetNotificationPermissionStatusUseCaseImpl
+    ): GetNotificationPermissionStatusUseCase
 
 }

--- a/core/data/src/main/kotlin/com/team/bottles/core/data/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/team/bottles/core/data/repository/UserRepositoryImpl.kt
@@ -55,4 +55,7 @@ class UserRepositoryImpl @Inject constructor(
         userDataSource.updateActivateMatching(request = ActivateMatchingRequest(activate = isActivate))
     }
 
+    override suspend fun getNotificationPermissionStatus(): Boolean =
+        deviceDataSource.getIsAllowedNotificationPermission()
+
 }

--- a/core/domain/src/main/kotlin/com/team/bottles/core/domain/user/repository/UserRepository.kt
+++ b/core/domain/src/main/kotlin/com/team/bottles/core/domain/user/repository/UserRepository.kt
@@ -19,4 +19,6 @@ interface UserRepository {
 
     suspend fun updateActivateMatching(isActivate: Boolean)
 
+    suspend fun getNotificationPermissionStatus(): Boolean
+
 }

--- a/core/domain/src/main/kotlin/com/team/bottles/core/domain/user/usecase/GetNotificationPermissionStatusUseCase.kt
+++ b/core/domain/src/main/kotlin/com/team/bottles/core/domain/user/usecase/GetNotificationPermissionStatusUseCase.kt
@@ -1,0 +1,19 @@
+package com.team.bottles.core.domain.user.usecase
+
+import com.team.bottles.core.domain.user.repository.UserRepository
+import javax.inject.Inject
+
+class GetNotificationPermissionStatusUseCaseImpl @Inject constructor(
+    private val userRepository: UserRepository,
+): GetNotificationPermissionStatusUseCase {
+
+    override suspend fun invoke(): Boolean =
+        userRepository.getNotificationPermissionStatus()
+
+}
+
+interface GetNotificationPermissionStatusUseCase {
+
+    suspend operator fun invoke(): Boolean
+
+}

--- a/core/local/src/main/kotlin/com/team/bottles/local/datasource/DeviceDataSource.kt
+++ b/core/local/src/main/kotlin/com/team/bottles/local/datasource/DeviceDataSource.kt
@@ -4,4 +4,6 @@ interface DeviceDataSource {
 
     suspend fun getContacts(): List<String>
 
+    fun getIsAllowedNotificationPermission(): Boolean
+
 }

--- a/core/local/src/main/kotlin/com/team/bottles/local/datasource/DeviceDataSourceImpl.kt
+++ b/core/local/src/main/kotlin/com/team/bottles/local/datasource/DeviceDataSourceImpl.kt
@@ -1,9 +1,14 @@
 package com.team.bottles.local.datasource
 
+import android.Manifest
+import android.app.NotificationManager
 import android.content.ContentResolver
 import android.content.Context
+import android.content.pm.PackageManager
 import android.database.Cursor
+import android.os.Build
 import android.provider.ContactsContract
+import androidx.core.content.ContextCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
@@ -32,6 +37,15 @@ class DeviceDataSourceImpl @Inject constructor(
         }
 
         return contacts.toList()
+    }
+
+    override fun getIsAllowedNotificationPermission(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+        } else {
+            val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.areNotificationsEnabled()
+        }
     }
 
 }

--- a/core/ui/src/main/kotlin/com/team/bottles/core/ui/Alert.kt
+++ b/core/ui/src/main/kotlin/com/team/bottles/core/ui/Alert.kt
@@ -30,7 +30,7 @@ import com.team.bottles.core.designsystem.theme.BottlesTheme
 @Composable
 fun BottlesAlertConfirmDialog(
     modifier: Modifier = Modifier,
-    onClose: () -> Unit,
+    onClose: () -> Unit = { },
     onConfirm: () -> Unit,
     confirmButtonText: String,
     title: String,

--- a/feat/login/src/main/kotlin/com/team/bottles/feat/login/LoginRoute.kt
+++ b/feat/login/src/main/kotlin/com/team/bottles/feat/login/LoginRoute.kt
@@ -1,12 +1,18 @@
 package com.team.bottles.feat.login
 
+import android.Manifest
 import android.app.Activity
+import android.content.pm.PackageManager
+import android.os.Build
 import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.team.bottles.feat.login.di.clientEntryPoint
@@ -24,6 +30,21 @@ fun LoginRoute(
     val activity = LocalContext.current as Activity
     val kakaoClient by rememberUpdatedState(newValue = activity.clientEntryPoint.kakaoClient())
     val context = LocalContext.current
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            Toast.makeText(context, "알림 권한에 동의 하였습니다.", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+                permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
+        }
+    }
 
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { sideEffect ->

--- a/feat/mypage/src/main/kotlin/com/team/bottles/feat/mypage/MyPageScreen.kt
+++ b/feat/mypage/src/main/kotlin/com/team/bottles/feat/mypage/MyPageScreen.kt
@@ -34,7 +34,6 @@ internal fun MyPageScreen(
 
     if (uiState.showAccessPermissionGuideDialog) {
         BottlesAlertConfirmDialog(
-            onClose = { /* 닫을 수 없는 다이얼 로그 */ },
             onConfirm = { onIntent(MyPageIntent.ClickConfirmContactAccessButton) },
             confirmButtonText = "설정하러 가기",
             title = "연락처 접근 권한 안내",

--- a/feat/sandbeach/src/main/kotlin/com/team/bottles/feat/sandbeach/SandBeachRoute.kt
+++ b/feat/sandbeach/src/main/kotlin/com/team/bottles/feat/sandbeach/SandBeachRoute.kt
@@ -1,22 +1,15 @@
 package com.team.bottles.feat.sandbeach
 
-import android.Manifest
 import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
-import android.os.Build
 import android.widget.Toast
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -34,22 +27,6 @@ internal fun SandBeachRoute(
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
     val context = LocalContext.current
-    val notificationPermissionGranted =
-        remember {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
-            } else {
-                true
-            }
-        }
-    val permissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestPermission()
-    ) { isGranted ->
-        if (isGranted) {
-            viewModel.confirmPermission()
-            Toast.makeText(context, "알림 권한에 동의 하였습니다.", Toast.LENGTH_SHORT).show()
-        }
-    }
     val lifecycleOwner = LocalLifecycleOwner.current
 
     DisposableEffect(key1 = lifecycleOwner) {
@@ -63,14 +40,6 @@ internal fun SandBeachRoute(
 
         onDispose {
             lifecycleOwner.lifecycle.removeObserver(observer)
-        }
-    }
-
-    LaunchedEffect(notificationPermissionGranted) {
-        if (!notificationPermissionGranted) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-            }
         }
     }
 

--- a/feat/sandbeach/src/main/kotlin/com/team/bottles/feat/sandbeach/SandBeachScreen.kt
+++ b/feat/sandbeach/src/main/kotlin/com/team/bottles/feat/sandbeach/SandBeachScreen.kt
@@ -42,7 +42,6 @@ internal fun SandBeachScreen(
 ) {
     if (uiState.showDialog) {
         BottlesAlertConfirmDialog(
-            onClose = { /* 닫기 없음 */ },
             onConfirm = { onIntent(SandBeachIntent.ClickConfirmButton) },
             confirmButtonText = "업데이트 하기",
             title = "업데이트 안내",

--- a/feat/sandbeach/src/main/kotlin/com/team/bottles/feat/sandbeach/SandBeachViewModel.kt
+++ b/feat/sandbeach/src/main/kotlin/com/team/bottles/feat/sandbeach/SandBeachViewModel.kt
@@ -7,9 +7,6 @@ import com.team.bottles.core.domain.bottle.usecase.GetBottleListUseCase
 import com.team.bottles.core.domain.bottle.usecase.GetPingPongListUseCase
 import com.team.bottles.core.domain.profile.model.UserProfileStatus
 import com.team.bottles.core.domain.profile.usecase.GetUserProfileStatusUseCase
-import com.team.bottles.core.domain.user.model.Notification
-import com.team.bottles.core.domain.user.model.NotificationType
-import com.team.bottles.core.domain.user.usecase.UpdateSettingNotificationUseCase
 import com.team.bottles.exception.BottlesException
 import com.team.bottles.exception.BottlesNetworkException
 import com.team.bottles.feat.sandbeach.mvi.BottleStatus
@@ -25,7 +22,6 @@ class SandBeachViewModel @Inject constructor(
     private val getBottleListUseCase: GetBottleListUseCase,
     private val getPingPongListUseCase: GetPingPongListUseCase,
     private val getRequiredAppVersionUseCase: GetRequiredAppVersionUseCase,
-    private val updateSettingNotificationUseCase: UpdateSettingNotificationUseCase,
     savedStateHandle: SavedStateHandle
 ) : BaseViewModel<SandBeachUiState, SandBeachSideEffect, SandBeachIntent>(savedStateHandle) {
 
@@ -149,19 +145,6 @@ class SandBeachViewModel @Inject constructor(
 
     private fun navigateToPlayStore() {
         postSideEffect(SandBeachSideEffect.NavigateToPlayStore)
-    }
-
-    fun confirmPermission() {
-        launch {
-            NotificationType.entries.forEach { type ->
-                updateSettingNotificationUseCase(
-                    notification = Notification(
-                        notificationType = type,
-                        enabled = true
-                    )
-                )
-            }
-        }
     }
 
 }

--- a/feat/setting/src/main/kotlin/com/team/bottles/feat/setting/notification/NotificationSettingRoute.kt
+++ b/feat/setting/src/main/kotlin/com/team/bottles/feat/setting/notification/NotificationSettingRoute.kt
@@ -1,10 +1,18 @@
 package com.team.bottles.feat.setting.notification
 
+import android.Manifest
+import android.app.Activity
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
 import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.ActivityCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.team.bottles.feat.setting.notification.mvi.NotificationSideEffect
@@ -16,12 +24,35 @@ internal fun NotificationSettingRoute(
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    val activityIntent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+        putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+    }
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            Toast.makeText(context, "알림 권한에 동의 하였습니다.", Toast.LENGTH_SHORT).show()
+        }
+    }
 
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
                 is NotificationSideEffect.NavigateToMyPage -> navigateToMyPage()
-                is NotificationSideEffect.ShowErrorMessage -> Toast.makeText(context, sideEffect.message, Toast.LENGTH_SHORT).show()
+                is NotificationSideEffect.ShowErrorMessage -> {
+                    Toast.makeText(context, sideEffect.message, Toast.LENGTH_SHORT).show()
+                }
+                is NotificationSideEffect.RequireNotificationPermission -> {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        if (!ActivityCompat.shouldShowRequestPermissionRationale(context as Activity, Manifest.permission.POST_NOTIFICATIONS)) {
+                            context.startActivity(activityIntent)
+                        } else {
+                            permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                        }
+                    } else {
+                        context.startActivity(activityIntent)
+                    }
+                }
             }
         }
     }

--- a/feat/setting/src/main/kotlin/com/team/bottles/feat/setting/notification/NotificationSettingScreen.kt
+++ b/feat/setting/src/main/kotlin/com/team/bottles/feat/setting/notification/NotificationSettingScreen.kt
@@ -17,6 +17,7 @@ import com.team.bottles.core.designsystem.R
 import com.team.bottles.core.designsystem.components.bars.BottlesTopBar
 import com.team.bottles.core.designsystem.modifier.noRippleClickable
 import com.team.bottles.core.designsystem.theme.BottlesTheme
+import com.team.bottles.core.ui.BottlesAlertConfirmDialog
 import com.team.bottles.core.ui.BottlesErrorScreen
 import com.team.bottles.feat.setting.components.NotificationSetting
 import com.team.bottles.feat.setting.notification.mvi.NotificationIntent
@@ -27,6 +28,15 @@ internal fun NotificationSettingScreen(
     uiState: NotificationUiState,
     onIntent: (NotificationIntent) -> Unit,
 ) {
+    if (uiState.isShowDialog) {
+        BottlesAlertConfirmDialog(
+            onConfirm = { onIntent(NotificationIntent.ClickGoSystemSetting) },
+            confirmButtonText = "설정하러 가기",
+            title = "알림 권한 안내",
+            content = "설정 > 애플리케이션 > '보틀' > 권한에서 알림을 허용해주세요."
+        )
+    }
+
     if (uiState.isError) {
         BottlesErrorScreen(
             modifier = Modifier.systemBarsPadding(),

--- a/feat/setting/src/main/kotlin/com/team/bottles/feat/setting/notification/mvi/NotificationIntent.kt
+++ b/feat/setting/src/main/kotlin/com/team/bottles/feat/setting/notification/mvi/NotificationIntent.kt
@@ -16,4 +16,6 @@ sealed interface NotificationIntent : UiIntent {
 
     data object ClickRetryButton : NotificationIntent
 
+    data object ClickGoSystemSetting : NotificationIntent
+
 }

--- a/feat/setting/src/main/kotlin/com/team/bottles/feat/setting/notification/mvi/NotificationSideEffect.kt
+++ b/feat/setting/src/main/kotlin/com/team/bottles/feat/setting/notification/mvi/NotificationSideEffect.kt
@@ -8,4 +8,6 @@ sealed interface NotificationSideEffect : UiSideEffect {
 
     data class ShowErrorMessage(val message: String) : NotificationSideEffect
 
+    data object RequireNotificationPermission : NotificationSideEffect
+
 }

--- a/feat/setting/src/main/kotlin/com/team/bottles/feat/setting/notification/mvi/NotificationUiState.kt
+++ b/feat/setting/src/main/kotlin/com/team/bottles/feat/setting/notification/mvi/NotificationUiState.kt
@@ -8,7 +8,9 @@ data class NotificationUiState(
     val isConversation: Boolean = false,
     val isMarketingResponse: Boolean = false,
     val isError: Boolean = false,
-    val notificationState: NotificationState = NotificationState.INIT
+    val notificationState: NotificationState = NotificationState.INIT,
+    val isAllowedNotificationPerMission: Boolean = false,
+    val isShowDialog: Boolean = false,
 ) : UiState {
 
     enum class NotificationState {

--- a/feat/splash/src/main/kotlin/com/team/bottles/feat/splash/SplashScreen.kt
+++ b/feat/splash/src/main/kotlin/com/team/bottles/feat/splash/SplashScreen.kt
@@ -27,7 +27,6 @@ internal fun SplashScreen(
 ) {
     if (uiState.showDialog) {
         BottlesAlertConfirmDialog(
-            onClose = { /* 닫기 없음 */ },
             onConfirm = { onIntent(SplashIntent.ClickConfirmButton) },
             confirmButtonText = "업데이트 하기",
             title = "업데이트 안내",


### PR DESCRIPTION
## 관련 이슈
- closed #109

## 작업한 내용
- 모래사장 알림 권한 요청 제거
- 로그인 화면 알림 권한 요청 추가
- 마이페이지에서 알림 설정시, 알림 권한 상태에 따라 권한 요청
  - 다이얼로그 화면 출력
- 권한 상태 가져오는 로직 추가
  - API 33 이상은 런타임에 권한 요청 (단, 다시 보지 않기 선택한 권한 선택 시 시스템 권한 화면으로 넘어가게 구현)
  - API 33 미만은 시스템 권한 화면으로 넘어가게 구현
