### PR TITLE
[Feat] Photo Picker를 활용한 프로필 이미지 수정 기능 구현 (웹뷰)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,16 @@
         android:hardwareAccelerated="true"
         tools:ignore="DiscouragedApi">
 
+        <service android:name="com.google.android.gms.metadata.ModuleDependencies"
+            android:enabled="false"
+            android:exported="false"
+            tools:ignore="MissingClass">
+            <intent-filter>
+                <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
+            </intent-filter>
+            <meta-data android:name="photopicker_activity:0:required" android:value="" />
+        </service>
+
         <service
             android:name=".BottleFcmService"
             android:exported="false">

--- a/core/ui/src/main/kotlin/com/team/bottles/core/ui/WebView.kt
+++ b/core/ui/src/main/kotlin/com/team/bottles/core/ui/WebView.kt
@@ -1,13 +1,18 @@
 package com.team.bottles.core.ui
 
 import android.annotation.SuppressLint
+import android.net.Uri
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.webkit.ValueCallback
+import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebView.setWebContentsDebuggingEnabled
 import android.webkit.WebViewClient
-import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -25,11 +30,28 @@ fun BottlesWebView(
     webView: WebView,
 ) {
     var canGoBack by remember { mutableStateOf(false) }
+    var mFilePathCallback by remember { mutableStateOf<ValueCallback<Array<Uri>>?>(null) }
 
-    BackHandler(enabled = canGoBack) {
-        if (webView.canGoBack()) {
-            webView.goBack()
+    val photoPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia()
+    ) { uri ->
+        if (uri != null) {
+            mFilePathCallback?.onReceiveValue(arrayOf(uri))
+        } else {
+            mFilePathCallback?.onReceiveValue(null)
         }
+        mFilePathCallback = null
+    }
+
+    val multiplePhotoPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickMultipleVisualMedia()
+    ) { uris ->
+        if (uris.isNotEmpty()) {
+            mFilePathCallback?.onReceiveValue(uris.toTypedArray())
+        } else {
+            mFilePathCallback?.onReceiveValue(null)
+        }
+        mFilePathCallback = null
     }
 
     DisposableEffect(webView) {
@@ -50,6 +72,35 @@ fun BottlesWebView(
             resumeTimers()
 
             loadUrl(url)
+
+            webChromeClient = object : WebChromeClient() {
+                override fun onShowFileChooser(
+                    webView: WebView?,
+                    filePathCallback: ValueCallback<Array<Uri>>?,
+                    fileChooserParams: FileChooserParams?
+                ): Boolean {
+                    mFilePathCallback = filePathCallback
+
+                    val isMultipleSelect =
+                        fileChooserParams?.mode == FileChooserParams.MODE_OPEN_MULTIPLE
+
+                    if (isMultipleSelect) {
+                        multiplePhotoPickerLauncher.launch(
+                            PickVisualMediaRequest(
+                                ActivityResultContracts.PickVisualMedia.ImageOnly
+                            )
+                        )
+                    } else {
+                        photoPickerLauncher.launch(
+                            PickVisualMediaRequest(
+                                ActivityResultContracts.PickVisualMedia.ImageOnly
+                            )
+                        )
+                    }
+
+                    return true
+                }
+            }
 
             webViewClient = object : WebViewClient() {
                 override fun onPageFinished(view: WebView?, url: String?) {

--- a/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/edit/EditProfileBridge.kt
+++ b/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/edit/EditProfileBridge.kt
@@ -1,6 +1,7 @@
 package com.team.bottles.feat.profile.edit
 
 import android.webkit.JavascriptInterface
+import com.team.bottles.core.common.base.BaseBridgeListener
 
 internal class EditProfileBridge(private val onAction: (EditProfileWebAction) -> Unit) :
     EditProfileBridgeListener {
@@ -11,8 +12,8 @@ internal class EditProfileBridge(private val onAction: (EditProfileWebAction) ->
     }
 
     @JavascriptInterface
-    override fun openWebView(url: String) {
-        // TODO : 웹 메서드 생성시 구현
+    override fun onToastOpen(message: String) {
+        onAction(EditProfileWebAction.OnToastOpen(message = message))
     }
 
     companion object {
@@ -25,12 +26,8 @@ sealed interface EditProfileWebAction {
 
     data object OnWebViewClose : EditProfileWebAction
 
-}
-
-interface EditProfileBridgeListener {
-
-    fun onWebViewClose()
-
-    fun openWebView(url: String)
+    data class OnToastOpen(val message: String) : EditProfileWebAction
 
 }
+
+interface EditProfileBridgeListener : BaseBridgeListener

--- a/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/edit/EditProfileRoute.kt
+++ b/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/edit/EditProfileRoute.kt
@@ -1,8 +1,10 @@
 package com.team.bottles.feat.profile.edit
 
+import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.team.bottles.feat.profile.edit.mvi.EditProfileSideEffect
@@ -12,12 +14,16 @@ internal fun EditProfileRoute(
     viewModel: EditProfileViewModel = hiltViewModel(),
     navigateToMyPage: () -> Unit
 ) {
+    val context = LocalContext.current
     val uiState by viewModel.state.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
                 is EditProfileSideEffect.NavigateToMyPage -> navigateToMyPage()
+                is EditProfileSideEffect.ShowToastMessage -> {
+                    Toast.makeText(context, sideEffect.message, Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }

--- a/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/edit/EditProfileScreen.kt
+++ b/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/edit/EditProfileScreen.kt
@@ -26,6 +26,11 @@ internal fun EditProfileScreen(
                 EditProfileBridge { webAction ->
                     when (webAction) {
                         is EditProfileWebAction.OnWebViewClose -> onIntent(EditProfileIntent.ClickWebCloseButton)
+                        is EditProfileWebAction.OnToastOpen -> onIntent(
+                            EditProfileIntent.ShowToastMessage(
+                                message = webAction.message
+                            )
+                        )
                     }
                 },
                 EditProfileBridge.NAME

--- a/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/edit/EditProfileViewModel.kt
+++ b/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/edit/EditProfileViewModel.kt
@@ -38,6 +38,7 @@ internal class EditProfileViewModel @Inject constructor(
     override suspend fun handleIntent(intent: EditProfileIntent) {
         when (intent) {
             is EditProfileIntent.ClickWebCloseButton -> navigateToMyPage()
+            is EditProfileIntent.ShowToastMessage -> showToastMessage(message = intent.message)
         }
     }
 
@@ -47,6 +48,10 @@ internal class EditProfileViewModel @Inject constructor(
 
     private fun navigateToMyPage() {
         postSideEffect(EditProfileSideEffect.NavigateToMyPage)
+    }
+
+    private fun showToastMessage(message: String) {
+        postSideEffect(EditProfileSideEffect.ShowToastMessage(message = message))
     }
 
 }

--- a/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/edit/mvi/EditProfileIntent.kt
+++ b/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/edit/mvi/EditProfileIntent.kt
@@ -6,4 +6,6 @@ sealed interface EditProfileIntent : UiIntent {
 
     data object ClickWebCloseButton : EditProfileIntent
 
+    data class ShowToastMessage(val message: String) : EditProfileIntent
+
 }

--- a/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/edit/mvi/EditProfileSideEffect.kt
+++ b/feat/profile/src/main/kotlin/com/team/bottles/feat/profile/edit/mvi/EditProfileSideEffect.kt
@@ -6,4 +6,6 @@ sealed interface EditProfileSideEffect : UiSideEffect {
 
     data object NavigateToMyPage : EditProfileSideEffect
 
+    data class ShowToastMessage(val message: String) : EditProfileSideEffect
+
 }


### PR DESCRIPTION
## 작업한 내용
- API 28~29에서 Photo Picker 사용을 위한 서비스 모듈 추가
- 프로필 수정 화면에서 `onToastOpen` 웹 이벤트 구현
- 프로필 이미지 수정 기능 구현
