### PR TITLE
[Fix] UserProfielResponse 데이터 필드 null-safety 적용

### DIFF
--- a/core/data/src/main/kotlin/com/team/bottles/core/data/mapper/UserProfileResponseMapper.kt
+++ b/core/data/src/main/kotlin/com/team/bottles/core/data/mapper/UserProfileResponseMapper.kt
@@ -35,9 +35,9 @@ fun UserProfileSelectDTO.toUserProfileSelect(): UserProfileSelect =
         interest = this.interest.toInterest(),
         job = this.job,
         height = this.height,
-        smoking = this.smoking,
-        alcohol = this.alcohol,
-        religion = this.religion,
+        smoking = this.smoking?: "",
+        alcohol = this.alcohol?: "",
+        religion = this.religion?: "",
         region = this.region.toRegion(),
     )
 

--- a/core/network/src/main/kotlin/com/team/bottles/network/dto/profile/reponse/UserProfileResponse.kt
+++ b/core/network/src/main/kotlin/com/team/bottles/network/dto/profile/reponse/UserProfileResponse.kt
@@ -21,9 +21,9 @@ data class UserProfileSelectDTO(
     @SerialName("interest") val interest: InterestDto,
     @SerialName("job") val job: String,
     @SerialName("height") val height: Int,
-    @SerialName("smoking") val smoking: String,
-    @SerialName("alcohol") val alcohol: String,
-    @SerialName("religion") val religion: String,
+    @SerialName("smoking") val smoking: String?,
+    @SerialName("alcohol") val alcohol: String?,
+    @SerialName("religion") val religion: String?,
     @SerialName("region") val region: RegionDto,
 )
 


### PR DESCRIPTION
## 작업한 내용
- `UserProfileResponse` 데이터 필드 null-safety 적용
  - `smoking`, `alcohol`, `religion` 필드 적용